### PR TITLE
Auto quantization (#2)

### DIFF
--- a/analysis/statistics/037939ff02bddec74329ea92860048df64f63d75.txt
+++ b/analysis/statistics/037939ff02bddec74329ea92860048df64f63d75.txt
@@ -1,0 +1,46 @@
+
+changeset: 1484:037939ff02bddec74329ea92860048df64f63d75
+char kNewtonVersion[] = "0.3-alpha-1484 (037939ff02bddec74329ea92860048df64f63d75) (build 05-07-2023-13:26-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/0e97c5693eba0399a0b980aa080ca2382e025ac3.txt
+++ b/analysis/statistics/0e97c5693eba0399a0b980aa080ca2382e025ac3.txt
@@ -1,0 +1,46 @@
+
+changeset: 1499:0e97c5693eba0399a0b980aa080ca2382e025ac3
+char kNewtonVersion[] = "0.3-alpha-1499 (0e97c5693eba0399a0b980aa080ca2382e025ac3) (build 06-06-2023-19:15-pei@pei-G5-5500-Linux-5.19.0-43-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/0ea368e57710f6424cb888cebaff3fbd0e319897.txt
+++ b/analysis/statistics/0ea368e57710f6424cb888cebaff3fbd0e319897.txt
@@ -1,0 +1,46 @@
+
+changeset: 1489:0ea368e57710f6424cb888cebaff3fbd0e319897
+char kNewtonVersion[] = "0.3-alpha-1489 (0ea368e57710f6424cb888cebaff3fbd0e319897) (build 05-15-2023-18:05-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/1991dd2af3a26c4a43535ed0171dd1ea373609d1.txt
+++ b/analysis/statistics/1991dd2af3a26c4a43535ed0171dd1ea373609d1.txt
@@ -1,0 +1,46 @@
+
+changeset: 1501:1991dd2af3a26c4a43535ed0171dd1ea373609d1
+char kNewtonVersion[] = "0.3-alpha-1501 (1991dd2af3a26c4a43535ed0171dd1ea373609d1) (build 06-07-2023-13:46-pei@pei-G5-5500-Linux-5.19.0-43-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/1b9cd1f4be586422deeb7650e112634a8b818569.txt
+++ b/analysis/statistics/1b9cd1f4be586422deeb7650e112634a8b818569.txt
@@ -1,0 +1,46 @@
+
+changeset: 1481:1b9cd1f4be586422deeb7650e112634a8b818569
+char kNewtonVersion[] = "0.3-alpha-1481 (1b9cd1f4be586422deeb7650e112634a8b818569) (build 05-01-2023-20:15-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/1f6ae86b5d7aad826042279c0d63ad1adca38ceb.txt
+++ b/analysis/statistics/1f6ae86b5d7aad826042279c0d63ad1adca38ceb.txt
@@ -1,0 +1,46 @@
+
+changeset: 1504:1f6ae86b5d7aad826042279c0d63ad1adca38ceb
+char kNewtonVersion[] = "0.3-alpha-1504 (1f6ae86b5d7aad826042279c0d63ad1adca38ceb) (build 06-07-2023-21:18-pei@pei-G5-5500-Linux-5.19.0-43-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/2eda94ba67b6488d50f1ed827b16af60321719d2.txt
+++ b/analysis/statistics/2eda94ba67b6488d50f1ed827b16af60321719d2.txt
@@ -1,0 +1,46 @@
+
+changeset: 1482:2eda94ba67b6488d50f1ed827b16af60321719d2
+char kNewtonVersion[] = "0.3-alpha-1482 (2eda94ba67b6488d50f1ed827b16af60321719d2) (build 05-12-2023-17:25-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/3eb50fb2fc3123aa810f455f00c9f1c545f75477.txt
+++ b/analysis/statistics/3eb50fb2fc3123aa810f455f00c9f1c545f75477.txt
@@ -1,0 +1,46 @@
+
+changeset: 1492:3eb50fb2fc3123aa810f455f00c9f1c545f75477
+char kNewtonVersion[] = "0.3-alpha-1492 (3eb50fb2fc3123aa810f455f00c9f1c545f75477) (build 05-17-2023-16:26-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/49c88625fb70a04406eb65eaa2d91cc5be67ec18.txt
+++ b/analysis/statistics/49c88625fb70a04406eb65eaa2d91cc5be67ec18.txt
@@ -1,0 +1,46 @@
+
+changeset: 1507:49c88625fb70a04406eb65eaa2d91cc5be67ec18
+char kNewtonVersion[] = "0.3-alpha-1507 (49c88625fb70a04406eb65eaa2d91cc5be67ec18) (build 06-14-2023-16:00-pei@pei-G5-5500-Linux-5.19.0-43-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/4e1b977ecd75c991cd068d5fdcde07824b4ed5dc.txt
+++ b/analysis/statistics/4e1b977ecd75c991cd068d5fdcde07824b4ed5dc.txt
@@ -1,0 +1,46 @@
+
+changeset: 1505:4e1b977ecd75c991cd068d5fdcde07824b4ed5dc
+char kNewtonVersion[] = "0.3-alpha-1505 (4e1b977ecd75c991cd068d5fdcde07824b4ed5dc) (build 06-13-2023-18:51-pei@pei-G5-5500-Linux-5.19.0-43-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/4f334c0c4045c4e2e95952baeab82d8d32e35a5d.txt
+++ b/analysis/statistics/4f334c0c4045c4e2e95952baeab82d8d32e35a5d.txt
@@ -1,0 +1,46 @@
+
+changeset: 1485:4f334c0c4045c4e2e95952baeab82d8d32e35a5d
+char kNewtonVersion[] = "0.3-alpha-1485 (4f334c0c4045c4e2e95952baeab82d8d32e35a5d) (build 05-15-2023-12:28-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/55774d8e473f64a6532a76dfc92b796ced44617a.txt
+++ b/analysis/statistics/55774d8e473f64a6532a76dfc92b796ced44617a.txt
@@ -1,0 +1,46 @@
+
+changeset: 1487:55774d8e473f64a6532a76dfc92b796ced44617a
+char kNewtonVersion[] = "0.3-alpha-1487 (55774d8e473f64a6532a76dfc92b796ced44617a) (build 05-09-2023-13:21-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/55be81ef3bc022adb311736f398bc7f58b115c59.txt
+++ b/analysis/statistics/55be81ef3bc022adb311736f398bc7f58b115c59.txt
@@ -1,0 +1,46 @@
+
+changeset: 1486:55be81ef3bc022adb311736f398bc7f58b115c59
+char kNewtonVersion[] = "0.3-alpha-1486 (55be81ef3bc022adb311736f398bc7f58b115c59) (build 05-15-2023-13:05-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/55ed2ed7ccb6bf1ee8f1928cf30228339c2a99be.txt
+++ b/analysis/statistics/55ed2ed7ccb6bf1ee8f1928cf30228339c2a99be.txt
@@ -1,0 +1,46 @@
+
+changeset: 1492:55ed2ed7ccb6bf1ee8f1928cf30228339c2a99be
+char kNewtonVersion[] = "0.3-alpha-1492 (55ed2ed7ccb6bf1ee8f1928cf30228339c2a99be) (build 05-11-2023-20:01-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/5693026eb3620065f35a8222bf3202096ca061c6.txt
+++ b/analysis/statistics/5693026eb3620065f35a8222bf3202096ca061c6.txt
@@ -1,0 +1,46 @@
+
+changeset: 1495:5693026eb3620065f35a8222bf3202096ca061c6
+char kNewtonVersion[] = "0.3-alpha-1495 (5693026eb3620065f35a8222bf3202096ca061c6) (build 05-22-2023-11:03-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/5a6215a127c6ae78b0faac6af09988e13b927474.txt
+++ b/analysis/statistics/5a6215a127c6ae78b0faac6af09988e13b927474.txt
@@ -1,0 +1,46 @@
+
+changeset: 1482:5a6215a127c6ae78b0faac6af09988e13b927474
+char kNewtonVersion[] = "0.3-alpha-1482 (5a6215a127c6ae78b0faac6af09988e13b927474) (build 05-01-2023-20:21-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/6b7355a4d6ed01b8ad7c698f9334a4f20f0a9a20.txt
+++ b/analysis/statistics/6b7355a4d6ed01b8ad7c698f9334a4f20f0a9a20.txt
@@ -1,0 +1,46 @@
+
+changeset: 1510:6b7355a4d6ed01b8ad7c698f9334a4f20f0a9a20
+char kNewtonVersion[] = "0.3-alpha-1510 (6b7355a4d6ed01b8ad7c698f9334a4f20f0a9a20) (build 06-16-2023-14:45-pei@pei-G5-5500-Linux-5.19.0-43-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/6e42134f2a8790e917eacbe5c1c30ed271dcb5a0.txt
+++ b/analysis/statistics/6e42134f2a8790e917eacbe5c1c30ed271dcb5a0.txt
@@ -1,0 +1,46 @@
+
+changeset: 1503:6e42134f2a8790e917eacbe5c1c30ed271dcb5a0
+char kNewtonVersion[] = "0.3-alpha-1503 (6e42134f2a8790e917eacbe5c1c30ed271dcb5a0) (build 06-07-2023-20:46-pei@pei-G5-5500-Linux-5.19.0-43-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/76412daca76f0764254bac1290f563dffd39b5eb.txt
+++ b/analysis/statistics/76412daca76f0764254bac1290f563dffd39b5eb.txt
@@ -1,0 +1,46 @@
+
+changeset: 1495:76412daca76f0764254bac1290f563dffd39b5eb
+char kNewtonVersion[] = "0.3-alpha-1495 (76412daca76f0764254bac1290f563dffd39b5eb) (build 05-12-2023-17:21-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/76d7464f83d3682d7290233a8c47d2240af80519.txt
+++ b/analysis/statistics/76d7464f83d3682d7290233a8c47d2240af80519.txt
@@ -1,0 +1,46 @@
+
+changeset: 1487:76d7464f83d3682d7290233a8c47d2240af80519
+char kNewtonVersion[] = "0.3-alpha-1487 (76d7464f83d3682d7290233a8c47d2240af80519) (build 05-15-2023-13:16-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/8c330dddffac97c90694800b7e253f9359d7049b.txt
+++ b/analysis/statistics/8c330dddffac97c90694800b7e253f9359d7049b.txt
@@ -1,0 +1,46 @@
+
+changeset: 1506:8c330dddffac97c90694800b7e253f9359d7049b
+char kNewtonVersion[] = "0.3-alpha-1506 (8c330dddffac97c90694800b7e253f9359d7049b) (build 06-13-2023-19:00-pei@pei-G5-5500-Linux-5.19.0-43-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/904f911572e0d79684beb60960146404aecbbc92.txt
+++ b/analysis/statistics/904f911572e0d79684beb60960146404aecbbc92.txt
@@ -1,0 +1,46 @@
+
+changeset: 1500:904f911572e0d79684beb60960146404aecbbc92
+char kNewtonVersion[] = "0.3-alpha-1500 (904f911572e0d79684beb60960146404aecbbc92) (build 06-07-2023-12:34-pei@pei-G5-5500-Linux-5.19.0-43-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/91947db0600ad544577a7cf19fe3c77b123a09c6.txt
+++ b/analysis/statistics/91947db0600ad544577a7cf19fe3c77b123a09c6.txt
@@ -1,0 +1,46 @@
+
+changeset: 1483:91947db0600ad544577a7cf19fe3c77b123a09c6
+char kNewtonVersion[] = "0.3-alpha-1483 (91947db0600ad544577a7cf19fe3c77b123a09c6) (build 05-07-2023-13:24-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/9879c5c97f8193458103ad26666566c3f914ec69.txt
+++ b/analysis/statistics/9879c5c97f8193458103ad26666566c3f914ec69.txt
@@ -1,0 +1,46 @@
+
+changeset: 1498:9879c5c97f8193458103ad26666566c3f914ec69
+char kNewtonVersion[] = "0.3-alpha-1498 (9879c5c97f8193458103ad26666566c3f914ec69) (build 06-05-2023-16:45-pei@pei-G5-5500-Linux-5.19.0-43-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/a12995cdca9486a8fccd8528ffa11b22db6e322c.txt
+++ b/analysis/statistics/a12995cdca9486a8fccd8528ffa11b22db6e322c.txt
@@ -1,0 +1,46 @@
+
+changeset: 1485:a12995cdca9486a8fccd8528ffa11b22db6e322c
+char kNewtonVersion[] = "0.3-alpha-1485 (a12995cdca9486a8fccd8528ffa11b22db6e322c) (build 05-07-2023-15:09-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/ae1179cbba50eb58e99d58e88bbcaf134208264a.txt
+++ b/analysis/statistics/ae1179cbba50eb58e99d58e88bbcaf134208264a.txt
@@ -1,0 +1,46 @@
+
+changeset: 1486:ae1179cbba50eb58e99d58e88bbcaf134208264a
+char kNewtonVersion[] = "0.3-alpha-1486 (ae1179cbba50eb58e99d58e88bbcaf134208264a) (build 05-09-2023-11:14-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/b55cd953aecf398f5ea81b587d0964104351137d.txt
+++ b/analysis/statistics/b55cd953aecf398f5ea81b587d0964104351137d.txt
@@ -1,0 +1,46 @@
+
+changeset: 1484:b55cd953aecf398f5ea81b587d0964104351137d
+char kNewtonVersion[] = "0.3-alpha-1484 (b55cd953aecf398f5ea81b587d0964104351137d) (build 05-15-2023-12:18-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/b57e5017003ddf3a74b28d11291b30c4667bfa74.txt
+++ b/analysis/statistics/b57e5017003ddf3a74b28d11291b30c4667bfa74.txt
@@ -1,0 +1,46 @@
+
+changeset: 1509:b57e5017003ddf3a74b28d11291b30c4667bfa74
+char kNewtonVersion[] = "0.3-alpha-1509 (b57e5017003ddf3a74b28d11291b30c4667bfa74) (build 06-14-2023-20:06-pei@pei-G5-5500-Linux-5.19.0-43-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/bd31828fc5af3a17a056eb19063d7349ae2bd9a1.txt
+++ b/analysis/statistics/bd31828fc5af3a17a056eb19063d7349ae2bd9a1.txt
@@ -1,0 +1,46 @@
+
+changeset: 1497:bd31828fc5af3a17a056eb19063d7349ae2bd9a1
+char kNewtonVersion[] = "0.3-alpha-1497 (bd31828fc5af3a17a056eb19063d7349ae2bd9a1) (build 05-31-2023-16:03-pei@pei-G5-5500-Linux-5.19.0-42-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/c279448a8c5e772f9456200999daf302315563a5.txt
+++ b/analysis/statistics/c279448a8c5e772f9456200999daf302315563a5.txt
@@ -1,0 +1,46 @@
+
+changeset: 1490:c279448a8c5e772f9456200999daf302315563a5
+char kNewtonVersion[] = "0.3-alpha-1490 (c279448a8c5e772f9456200999daf302315563a5) (build 05-11-2023-16:35-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/cb14cf5545715f1cfc7d1b362a6c646fd988aafe.txt
+++ b/analysis/statistics/cb14cf5545715f1cfc7d1b362a6c646fd988aafe.txt
@@ -1,0 +1,46 @@
+
+changeset: 1480:cb14cf5545715f1cfc7d1b362a6c646fd988aafe
+char kNewtonVersion[] = "0.3-alpha-1480 (cb14cf5545715f1cfc7d1b362a6c646fd988aafe) (build 05-01-2023-11:20-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/cf7e76b43f1222dc65bc8da8adaaa16595376aa7.txt
+++ b/analysis/statistics/cf7e76b43f1222dc65bc8da8adaaa16595376aa7.txt
@@ -1,0 +1,46 @@
+
+changeset: 1496:cf7e76b43f1222dc65bc8da8adaaa16595376aa7
+char kNewtonVersion[] = "0.3-alpha-1496 (cf7e76b43f1222dc65bc8da8adaaa16595376aa7) (build 05-24-2023-17:32-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/d0d2af75e883590773e3e9933b5b4dbe4a9f46cf.txt
+++ b/analysis/statistics/d0d2af75e883590773e3e9933b5b4dbe4a9f46cf.txt
@@ -1,0 +1,46 @@
+
+changeset: 1493:d0d2af75e883590773e3e9933b5b4dbe4a9f46cf
+char kNewtonVersion[] = "0.3-alpha-1493 (d0d2af75e883590773e3e9933b5b4dbe4a9f46cf) (build 05-17-2023-17:20-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/d2cf16cfab9b501f23b26ed9421a66d633d52d38.txt
+++ b/analysis/statistics/d2cf16cfab9b501f23b26ed9421a66d633d52d38.txt
@@ -1,0 +1,46 @@
+
+changeset: 1508:d2cf16cfab9b501f23b26ed9421a66d633d52d38
+char kNewtonVersion[] = "0.3-alpha-1508 (d2cf16cfab9b501f23b26ed9421a66d633d52d38) (build 06-14-2023-16:12-pei@pei-G5-5500-Linux-5.19.0-43-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/ea6ea1a56c0d27e2eae70b25f6c90a5a6b004ff9.txt
+++ b/analysis/statistics/ea6ea1a56c0d27e2eae70b25f6c90a5a6b004ff9.txt
@@ -1,0 +1,46 @@
+
+changeset: 1491:ea6ea1a56c0d27e2eae70b25f6c90a5a6b004ff9
+char kNewtonVersion[] = "0.3-alpha-1491 (ea6ea1a56c0d27e2eae70b25f6c90a5a6b004ff9) (build 05-11-2023-17:23-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/f0dd9235e099cd355073ed8d65f12fd8f81481b8.txt
+++ b/analysis/statistics/f0dd9235e099cd355073ed8d65f12fd8f81481b8.txt
@@ -1,0 +1,46 @@
+
+changeset: 1483:f0dd9235e099cd355073ed8d65f12fd8f81481b8
+char kNewtonVersion[] = "0.3-alpha-1483 (f0dd9235e099cd355073ed8d65f12fd8f81481b8) (build 05-13-2023-15:41-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/f507046b12ccddfbbba69a90139faba437067b96.txt
+++ b/analysis/statistics/f507046b12ccddfbbba69a90139faba437067b96.txt
@@ -1,0 +1,46 @@
+
+changeset: 1488:f507046b12ccddfbbba69a90139faba437067b96
+char kNewtonVersion[] = "0.3-alpha-1488 (f507046b12ccddfbbba69a90139faba437067b96) (build 05-09-2023-19:27-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/f5bd0a932b997f97198316e81441ba8cff989aec.txt
+++ b/analysis/statistics/f5bd0a932b997f97198316e81441ba8cff989aec.txt
@@ -1,0 +1,46 @@
+
+changeset: 1489:f5bd0a932b997f97198316e81441ba8cff989aec
+char kNewtonVersion[] = "0.3-alpha-1489 (f5bd0a932b997f97198316e81441ba8cff989aec) (build 05-11-2023-15:49-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/facbaee83daf692b9797d7cc63c55b3f7934642f.txt
+++ b/analysis/statistics/facbaee83daf692b9797d7cc63c55b3f7934642f.txt
@@ -1,0 +1,46 @@
+
+changeset: 1488:facbaee83daf692b9797d7cc63c55b3f7934642f
+char kNewtonVersion[] = "0.3-alpha-1488 (facbaee83daf692b9797d7cc63c55b3f7934642f) (build 05-15-2023-16:09-pei@pei-G5-5500-Linux-5.19.0-41-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/analysis/statistics/ff056d4ecc0dc7d05c2feca803f4ea35324659b3.txt
+++ b/analysis/statistics/ff056d4ecc0dc7d05c2feca803f4ea35324659b3.txt
@@ -1,0 +1,46 @@
+
+changeset: 1502:ff056d4ecc0dc7d05c2feca803f4ea35324659b3
+char kNewtonVersion[] = "0.3-alpha-1502 (ff056d4ecc0dc7d05c2feca803f4ea35324659b3) (build 06-07-2023-13:57-pei@pei-G5-5500-Linux-5.19.0-43-generic-x86_64)";
+\n./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+\n./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/applications/newton/llvm-ir/CHStone_test/dfadd/float64_add.cpp
+++ b/applications/newton/llvm-ir/CHStone_test/dfadd/float64_add.cpp
@@ -249,3 +249,103 @@ const float64 z_output[N] = {
 //      printf ("%d\n", main_result);
 //      return main_result;
 //    }
+
+// clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D ASSUME -D lowerBound=3 -D upperBound=10 -O3 -o float64_add_assume -lm
+#ifdef DEBUG
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define iteration_num 50000
+
+typedef struct timespec timespec;
+timespec diff(timespec start, timespec end)
+{
+    timespec temp;
+    if ((end.tv_nsec-start.tv_nsec)<0) {
+        temp.tv_sec = end.tv_sec-start.tv_sec-1;
+        temp.tv_nsec = 1000000000+end.tv_nsec-start.tv_nsec;
+    } else {
+        temp.tv_sec = end.tv_sec-start.tv_sec;
+        temp.tv_nsec = end.tv_nsec-start.tv_nsec;
+    }
+    return temp;
+}
+
+timespec sum(timespec t1, timespec t2) {
+    timespec temp;
+    if (t1.tv_nsec + t2.tv_nsec >= 1000000000) {
+        temp.tv_sec = t1.tv_sec + t2.tv_sec + 1;
+        temp.tv_nsec = t1.tv_nsec + t2.tv_nsec - 1000000000;
+    } else {
+        temp.tv_sec = t1.tv_sec + t2.tv_sec;
+        temp.tv_nsec = t1.tv_nsec + t2.tv_nsec;
+    }
+    return temp;
+}
+
+void printTimeSpec(timespec t, const char* prefix) {
+    printf("%s: %d.%09d\n", prefix, (int)t.tv_sec, (int)t.tv_nsec);
+}
+
+timespec tic( )
+{
+    timespec start_time;
+    clock_gettime(CLOCK_REALTIME, &start_time);
+    return start_time;
+}
+
+void toc( timespec* start_time, const char* prefix )
+{
+    timespec current_time;
+    clock_gettime(CLOCK_REALTIME, &current_time);
+    printTimeSpec( diff( *start_time, current_time ), prefix );
+    *start_time = current_time;
+}
+
+/*
+ * random floating point, [min, max]
+ * */
+static double
+randomDouble(double min, double max)
+{
+    double randDbValue = min + 1.0 * rand() / RAND_MAX * (max - min);
+    return randDbValue;
+}
+
+int main(int argc, char** argv) {
+    double parameters[2];
+    char *pEnd;
+    if (argc == 3) {
+        for (size_t idx = 0; idx < argc - 1; idx++) {
+            parameters[idx] = strtod(argv[idx + 1], &pEnd);
+        }
+    } else {
+        parameters[0] = 3.0;
+        parameters[1] = 10.0;
+    }
+    float64 result[iteration_num];
+    double xOps[iteration_num];
+    double yOps[iteration_num];
+    for (size_t idx = 0; idx < iteration_num; idx++) {
+        xOps[idx] = randomDouble(parameters[0], parameters[1]);
+        yOps[idx] = randomDouble(parameters[0] + 0.6, parameters[1] + 0.3);
+    }
+
+    timespec timer = tic();
+    for (size_t idx = 0; idx < iteration_num; idx++) {
+        result[idx] = float64_add(*(bmx055xAcceleration*)(&xOps[idx]), *(bmx055xAcceleration*)(&yOps[idx]));
+    }
+
+    toc(&timer, "computation delay");
+
+    printf("results: %llx, %llx, %llx, %llx, %llx\n", result[0], result[1], result[2], result[3], result[4]);
+//    printf("results: %f\t%f\t%f\t%f\t%f\n", *(double*)(&result[0]), *(double*)(&result[1]),
+//           *(double*)(&result[2]), *(double*)(&result[3]), *(double*)(&result[4]));
+
+    return 0;
+}
+#endif

--- a/applications/newton/llvm-ir/CHStone_test/dfadd/include/softfloat.c
+++ b/applications/newton/llvm-ir/CHStone_test/dfadd/include/softfloat.c
@@ -378,9 +378,26 @@ normalizeRoundAndPack:
 typedef float64 bmx055xAcceleration;
 typedef float64 bmx055yAcceleration;
 
+#ifndef lowerBound
+#define lowerBound 0
+#endif
+#ifndef upperBound
+#define upperBound 16
+#endif
+
 float64
 float64_add (bmx055xAcceleration a, bmx055yAcceleration b)
 {
+#ifdef ASSUME
+    double aLowerBound = lowerBound, aUpperBound = upperBound;
+    double bLowerBound = aLowerBound+0.6, bUpperBound = aUpperBound+0.3;
+    bmx055xAcceleration llhs = *(bmx055xAcceleration*)(&aLowerBound);
+    bmx055xAcceleration lrhs = *(bmx055xAcceleration*)(&aUpperBound);
+    bmx055yAcceleration rlhs = *(bmx055xAcceleration*)(&bLowerBound);
+    bmx055yAcceleration rrhs = *(bmx055xAcceleration*)(&bUpperBound);
+    __builtin_assume(a > llhs && a < lrhs);
+    __builtin_assume(b > rlhs && b < rrhs);
+#endif
   flag aSign, bSign;
 
   aSign = extractFloat64Sign (a);

--- a/applications/newton/llvm-ir/CHStone_test/dfdiv/float64_div.cpp
+++ b/applications/newton/llvm-ir/CHStone_test/dfdiv/float64_div.cpp
@@ -263,8 +263,26 @@ extern "C" {
 typedef float64 bmx055xAcceleration;
 typedef float64 bmx055yAcceleration;
 
+#ifndef lowerBound
+#define lowerBound 0
+#endif
+#ifndef upperBound
+#define upperBound 16
+#endif
+
 float64 float64_div (bmx055xAcceleration a, bmx055yAcceleration b)
 {
+//    printf("%llx, %f\n", a, *(double*)(&a));
+#ifdef ASSUME
+    double aLowerBound = lowerBound, aUpperBound = upperBound;
+    double bLowerBound = aLowerBound+0.6, bUpperBound = aUpperBound+0.3;
+    bmx055xAcceleration llhs = *(bmx055xAcceleration*)(&aLowerBound);
+    bmx055xAcceleration lrhs = *(bmx055xAcceleration*)(&aUpperBound);
+    bmx055yAcceleration rlhs = *(bmx055xAcceleration*)(&bLowerBound);
+    bmx055yAcceleration rrhs = *(bmx055xAcceleration*)(&bUpperBound);
+    __builtin_assume(a > llhs && a < lrhs);
+    __builtin_assume(b > rlhs && b < rrhs);
+#endif
   flag aSign, bSign, zSign;
   int16 aExp, bExp, zExp;
   bits64 aSig, bSig, zSig;
@@ -448,3 +466,104 @@ const float64 z_output[N] = {
 //      printf ("%d\n", main_result);
 //      return main_result;
 //    }
+
+
+// clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D ASSUME -D lowerBound=3 -D upperBound=10 -O3 -o float64_div_assume -lm
+#ifdef DEBUG
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define iteration_num 50000
+
+typedef struct timespec timespec;
+timespec diff(timespec start, timespec end)
+{
+    timespec temp;
+    if ((end.tv_nsec-start.tv_nsec)<0) {
+        temp.tv_sec = end.tv_sec-start.tv_sec-1;
+        temp.tv_nsec = 1000000000+end.tv_nsec-start.tv_nsec;
+    } else {
+        temp.tv_sec = end.tv_sec-start.tv_sec;
+        temp.tv_nsec = end.tv_nsec-start.tv_nsec;
+    }
+    return temp;
+}
+
+timespec sum(timespec t1, timespec t2) {
+    timespec temp;
+    if (t1.tv_nsec + t2.tv_nsec >= 1000000000) {
+        temp.tv_sec = t1.tv_sec + t2.tv_sec + 1;
+        temp.tv_nsec = t1.tv_nsec + t2.tv_nsec - 1000000000;
+    } else {
+        temp.tv_sec = t1.tv_sec + t2.tv_sec;
+        temp.tv_nsec = t1.tv_nsec + t2.tv_nsec;
+    }
+    return temp;
+}
+
+void printTimeSpec(timespec t, const char* prefix) {
+    printf("%s: %d.%09d\n", prefix, (int)t.tv_sec, (int)t.tv_nsec);
+}
+
+timespec tic( )
+{
+    timespec start_time;
+    clock_gettime(CLOCK_REALTIME, &start_time);
+    return start_time;
+}
+
+void toc( timespec* start_time, const char* prefix )
+{
+    timespec current_time;
+    clock_gettime(CLOCK_REALTIME, &current_time);
+    printTimeSpec( diff( *start_time, current_time ), prefix );
+    *start_time = current_time;
+}
+
+/*
+ * random floating point, [min, max]
+ * */
+static double
+randomDouble(double min, double max)
+{
+    double randDbValue = min + 1.0 * rand() / RAND_MAX * (max - min);
+    return randDbValue;
+}
+
+int main(int argc, char** argv) {
+    double parameters[2];
+    char *pEnd;
+    if (argc == 3) {
+        for (size_t idx = 0; idx < argc - 1; idx++) {
+            parameters[idx] = strtod(argv[idx + 1], &pEnd);
+        }
+    } else {
+        parameters[0] = 3.0;
+        parameters[1] = 10.0;
+    }
+    float64 result[iteration_num];
+    double xOps[iteration_num];
+    double yOps[iteration_num];
+    for (size_t idx = 0; idx < iteration_num; idx++) {
+        xOps[idx] = randomDouble(parameters[0], parameters[1]);
+        yOps[idx] = randomDouble(parameters[0] + 0.6, parameters[1] + 0.3);
+    }
+
+    timespec timer = tic();
+    for (size_t idx = 0; idx < iteration_num; idx++) {
+        result[idx] = float64_div(*(bmx055xAcceleration*)(&xOps[idx]), *(bmx055xAcceleration*)(&yOps[idx]));
+    }
+
+    toc(&timer, "computation delay");
+
+    printf("results: %llx, %llx, %llx, %llx, %llx\n", result[0], result[1], result[2], result[3], result[4]);
+//    printf("results: %f\t%f\t%f\t%f\t%f\n", *(double*)(&result[0]), *(double*)(&result[1]),
+//           *(double*)(&result[2]), *(double*)(&result[3]), *(double*)(&result[4]));
+
+    return 0;
+}
+#endif

--- a/applications/newton/llvm-ir/Makefile
+++ b/applications/newton/llvm-ir/Makefile
@@ -21,6 +21,19 @@ CC_FP_FLAG = -msoft-float
 OPT_FP_FLAG = --float-abi=soft
 endif
 
+# e.g. ASSUME=true lowerBound=-2 upperBound=2 make perf_madgwick
+ifdef ASSUME
+MACRO_FLAG += -D ASSUME
+endif
+
+ifdef lowerBound
+MACRO_FLAG += -D lowerBound=$(lowerBound)
+endif
+
+ifdef upperBound
+MACRO_FLAG += -D upperBound=$(upperBound)
+endif
+
 all: default
 
 default: application.ll simple_control_flow.ll inferBound.ll inferBoundControlFlow.ll e_exp.ll sincosf.ll e_log.ll e_acosh.ll e_j0.ll e_y0.ll e_rem_pio2.ll benchmark_suite.ll phi_two_global_arrays.ll func_call.ll test_shift.ll vec_add.ll vec_add_8.ll MadgwickAHRSfix.ll MadgwickAHRS_softfloat.ll MadgwickAHRS.ll arm_sqrt_q15.ll
@@ -33,7 +46,7 @@ MadgwickAHRS_softfloat.ll : MadgwickAHRS_softfloat.c
 
 %.ll : %.c
 	@echo Compiling $*.c
-	$(CC) $(TARGET_FLAG) $(CC_FP_FLAG) -g -O0 -Xclang -disable-O0-optnone -S -emit-llvm $(COMMON_FLAGS) -o $@ $<
+	$(CC) $(TARGET_FLAG) $(CC_FP_FLAG) $(MACRO_FLAG) -g -O0 -Xclang -disable-O0-optnone -S -emit-llvm $(COMMON_FLAGS) -o $@ $<
 	opt $@ $(OPT_FP_FLAG) --mem2reg --instsimplify -S -o $@
 
 clean::

--- a/applications/newton/llvm-ir/README.md
+++ b/applications/newton/llvm-ir/README.md
@@ -39,7 +39,7 @@ cd ../../../src/newton
 cd /path/to/Noisy-lang-compiler/applications/newton/llvm-ir
 make infer_bound_control_flow.ll
 cd ../../../src/newton
-./<newton-executable> --llvm-ir=../../applications/newton/llvm-ir/infer_bound_control_flow.ll --llvm-ir-liveness-check ../../applications/newton/sensors/test.nt
+./<newton-executable> --llvm-ir=../../applications/newton/llvm-ir/infer_bound_control_flow.ll --llvm-ir-liveness-check --llvm-ir-enable-overload --llvm-ir-enable-builtin-assume ../../applications/newton/sensors/test.nt
 opt infer_bound_control_flow_output.ll -O2 -S -o out.ll
 ```
 

--- a/applications/newton/llvm-ir/c-files/MadgwickAHRS.h
+++ b/applications/newton/llvm-ir/c-files/MadgwickAHRS.h
@@ -13,6 +13,9 @@
 #ifndef MadgwickAHRS_h
 #define MadgwickAHRS_h
 
+#include <math.h>
+#include <stdio.h>
+
 //----------------------------------------------------------------------------------------------------
 // Variable declaration
 
@@ -22,8 +25,10 @@
 //---------------------------------------------------------------------------------------------------
 // Function declarations
 
-void MadgwickAHRSupdate(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz);
-void MadgwickAHRSupdateIMU(float gx, float gy, float gz, float ax, float ay, float az);
+void MadgwickAHRSupdate(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz,
+                        float* q0_ptr, float* q1_ptr, float* q2_ptr, float* q3_ptr);
+void MadgwickAHRSupdateIMU(float gx, float gy, float gz, float ax, float ay, float az,
+                           float* q0_ptr, float* q1_ptr, float* q2_ptr, float* q3_ptr);
 
 #endif
 //=====================================================================================================

--- a/applications/newton/llvm-ir/c-files/MadgwickAHRSfix.h
+++ b/applications/newton/llvm-ir/c-files/MadgwickAHRSfix.h
@@ -17,11 +17,22 @@
 	POSSIBILITY OF SUCH DAMAGE.
 */
 
-#define FRAC_Q			8
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+#define FRAC_Q			10
+#define K   (1 << (FRAC_Q - 1))
 #define FRAC_BASE		(1<<FRAC_Q)
 #define DEC2FRAC(_d)		((uint8_t)(_d*FRAC_BASE))
+#define DISPLAY_INT(_x)		((_x>>FRAC_Q) + (((uint32_t)_x)>>(sizeof(int32_t)*FRAC_Q-1)))
+#define DISPLAY_FRAC(_y)	(((FRAC_BASE-1)&_y) * (10000/FRAC_BASE))
+#define FORMAT_FIXP		"%s%d.%04d"
 
-void	MadgwickAHRSupdate(int32_t gx, int32_t gy, int32_t gz, int32_t ax, int32_t ay, int32_t az, int32_t mx, int32_t my, int32_t mz);
-void	MadgwickAHRSupdateIMU(int32_t gx, int32_t gy, int32_t gz, int32_t ax, int32_t ay, int32_t az);
+void	MadgwickAHRSupdate(int32_t gx, int32_t gy, int32_t gz, int32_t ax, int32_t ay, int32_t az, int32_t mx, int32_t my, int32_t mz,
+                           int32_t* q0_ptr, int32_t* q1_ptr, int32_t* q2_ptr, int32_t* q3_ptr);
+void	MadgwickAHRSupdateIMU(int32_t gx, int32_t gy, int32_t gz, int32_t ax, int32_t ay, int32_t az,
+                              int32_t* q0_ptr, int32_t* q1_ptr, int32_t* q2_ptr, int32_t* q3_ptr);
 
 int32_t	sqrt_rsqrt(int32_t x, int recip);

--- a/applications/newton/llvm-ir/c-files/called_rem_pio2.c
+++ b/applications/newton/llvm-ir/c-files/called_rem_pio2.c
@@ -1,0 +1,371 @@
+#ifndef CALLED_REM_PIO2_C
+#define CALLED_REM_PIO2_C
+
+#ifdef __STDC__
+static const int init_jk[] = {2,3,4,6}; /* initial value for jk */
+#else
+static int init_jk[] = {2,3,4,6};
+#endif
+
+#ifdef __STDC__
+static const double PIo2[] = {
+#else
+static double PIo2[] = {
+#endif
+        1.57079625129699707031e+00, /* 0x3FF921FB, 0x40000000 */
+        7.54978941586159635335e-08, /* 0x3E74442D, 0x00000000 */
+        5.39030252995776476554e-15, /* 0x3CF84698, 0x80000000 */
+        3.28200341580791294123e-22, /* 0x3B78CC51, 0x60000000 */
+        1.27065575308067607349e-29, /* 0x39F01B83, 0x80000000 */
+        1.22933308981111328932e-36, /* 0x387A2520, 0x40000000 */
+        2.73370053816464559624e-44, /* 0x36E38222, 0x80000000 */
+        2.16741683877804819444e-51, /* 0x3569F31D, 0x00000000 */
+};
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+        zero   = 0.0,
+//        one    = 1.0,
+        two24   =  1.67772160000000000000e+07, /* 0x41700000, 0x00000000 */
+twon24  =  5.96046447753906250000e-08; /* 0x3E700000, 0x00000000 */
+
+#ifdef __STDC__
+int __kernel_rem_pio2(double *x, double *y, int e0, int nx, int prec, const int *ipio2)
+#else
+int __kernel_rem_pio2(x,y,e0,nx,prec,ipio2)
+        double x[], y[]; int e0,nx,prec; int ipio2[];
+#endif
+{
+    int jz,jx,jv,jp,jk,carry,n,iq[20],i,j,k,m,q0,ih;
+    double z,fw,f[20],fq[20],q[20];
+
+    /* initialize jk*/
+    jk = init_jk[prec];
+    jp = jk;
+
+    /* determine jx,jv,q0, note that 3>q0 */
+    jx =  nx-1;
+    jv = (e0-3)/24; if(jv<0) jv=0;
+    q0 =  e0-24*(jv+1);
+
+    /* set up f[0] to f[jx+jk] where f[jx+jk] = ipio2[jv+jk] */
+    j = jv-jx; m = jx+jk;
+    for(i=0;i<=m;i++,j++) f[i] = (j<0)? zero : (double) ipio2[j];
+
+    /* compute q[0],q[1],...q[jk] */
+    for (i=0;i<=jk;i++) {
+        for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j]; q[i] = fw;
+    }
+
+    jz = jk;
+    recompute:
+    /* distill q[] into iq[] reversingly */
+    for(i=0,j=jz,z=q[jz];j>0;i++,j--) {
+        fw    =  (double)((int)(twon24* z));
+        iq[i] =  (int)(z-two24*fw);
+        z     =  q[j-1]+fw;
+    }
+
+    /* compute n */
+    z  = scalbn(z,q0);		/* actual value of z */
+    z -= 8.0*floor(z*0.125);		/* trim off integer >= 8 */
+    n  = (int) z;
+    z -= (double)n;
+    ih = 0;
+    if(q0>0) {	/* need iq[jz-1] to determine n */
+        i  = (iq[jz-1]>>(24-q0)); n += i;
+        iq[jz-1] -= i<<(24-q0);
+        ih = iq[jz-1]>>(23-q0);
+    }
+    else if(q0==0) ih = iq[jz-1]>>23;
+    else if(z>=0.5) ih=2;
+
+    if(ih>0) {	/* q > 0.5 */
+        n += 1; carry = 0;
+        for(i=0;i<jz ;i++) {	/* compute 1-q */
+            j = iq[i];
+            if(carry==0) {
+                if(j!=0) {
+                    carry = 1; iq[i] = 0x1000000- j;
+                }
+            } else  iq[i] = 0xffffff - j;
+        }
+        if(q0>0) {		/* rare case: chance is 1 in 12 */
+            switch(q0) {
+                case 1:
+                    iq[jz-1] &= 0x7fffff; break;
+                case 2:
+                    iq[jz-1] &= 0x3fffff; break;
+            }
+        }
+        if(ih==2) {
+            z = one - z;
+            if(carry!=0) z -= scalbn(one,q0);
+        }
+    }
+
+    /* check if recomputation is needed */
+    if(z==zero) {
+        j = 0;
+        for (i=jz-1;i>=jk;i--) j |= iq[i];
+        if(j==0) { /* need recomputation */
+            for(k=1;iq[jk-k]==0;k++);   /* k = no. of terms needed */
+
+            for(i=jz+1;i<=jz+k;i++) {   /* add q[jz+1] to q[jz+k] */
+                f[jx+i] = (double) ipio2[jv+i];
+                for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j];
+                q[i] = fw;
+            }
+            jz += k;
+            goto recompute;
+        }
+    }
+
+    /* chop off zero terms */
+    if(z==0.0) {
+        jz -= 1; q0 -= 24;
+        while(iq[jz]==0) { jz--; q0-=24;}
+    } else { /* break z into 24-bit if necessary */
+        z = scalbn(z,-q0);
+        if(z>=two24) {
+            fw = (double)((int)(twon24*z));
+            iq[jz] = (int)(z-two24*fw);
+            jz += 1; q0 += 24;
+            iq[jz] = (int) fw;
+        } else iq[jz] = (int) z ;
+    }
+
+    /* convert integer "bit" chunk to floating-point value */
+    fw = scalbn(one,q0);
+    for(i=jz;i>=0;i--) {
+        q[i] = fw*(double)iq[i]; fw*=twon24;
+    }
+
+    /* compute PIo2[0,...,jp]*q[jz,...,0] */
+    for(i=jz;i>=0;i--) {
+        for(fw=0.0,k=0;k<=jp&&k<=jz-i;k++) fw += PIo2[k]*q[i+k];
+        fq[jz-i] = fw;
+    }
+
+    /* compress fq[] into y[] */
+    switch(prec) {
+        case 0:
+            fw = 0.0;
+            for (i=jz;i>=0;i--) fw += fq[i];
+            y[0] = (ih==0)? fw: -fw;
+            break;
+        case 1:
+        case 2:
+            fw = 0.0;
+            for (i=jz;i>=0;i--) fw += fq[i];
+            y[0] = (ih==0)? fw: -fw;
+            fw = fq[0]-fw;
+            for (i=1;i<=jz;i++) fw += fq[i];
+            y[1] = (ih==0)? fw: -fw;
+            break;
+        case 3:	/* painful */
+            for (i=jz;i>0;i--) {
+                fw      = fq[i-1]+fq[i];
+                fq[i]  += fq[i-1]-fw;
+                fq[i-1] = fw;
+            }
+            for (i=jz;i>1;i--) {
+                fw      = fq[i-1]+fq[i];
+                fq[i]  += fq[i-1]-fw;
+                fq[i-1] = fw;
+            }
+            for (fw=0.0,i=jz;i>=2;i--) fw += fq[i];
+            if(ih==0) {
+                y[0] =  fq[0]; y[1] =  fq[1]; y[2] =  fw;
+            } else {
+                y[0] = -fq[0]; y[1] = -fq[1]; y[2] = -fw;
+            }
+    }
+    return n&7;
+}
+
+
+/* @(#)e_rem_pio2.c 1.4 95/01/18 */
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunSoft, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice 
+ * is preserved.
+ * ====================================================
+ *
+ */
+
+/* __ieee754_rem_pio2(x,y)
+ * 
+ * return the remainder of x rem pi/2 in y[0]+y[1] 
+ * use __kernel_rem_pio2()
+ */
+
+//#include "fdlibm.h"
+
+/*
+ * Table of constants for 2/pi, 396 Hex digits (476 decimal) of 2/pi 
+ */
+#ifdef __STDC__
+static const int two_over_pi[] = {
+#else
+static int two_over_pi[] = {
+#endif
+        0xA2F983, 0x6E4E44, 0x1529FC, 0x2757D1, 0xF534DD, 0xC0DB62,
+        0x95993C, 0x439041, 0xFE5163, 0xABDEBB, 0xC561B7, 0x246E3A,
+        0x424DD2, 0xE00649, 0x2EEA09, 0xD1921C, 0xFE1DEB, 0x1CB129,
+        0xA73EE8, 0x8235F5, 0x2EBB44, 0x84E99C, 0x7026B4, 0x5F7E41,
+        0x3991D6, 0x398353, 0x39F49C, 0x845F8B, 0xBDF928, 0x3B1FF8,
+        0x97FFDE, 0x05980F, 0xEF2F11, 0x8B5A0A, 0x6D1F6D, 0x367ECF,
+        0x27CB09, 0xB74F46, 0x3F669E, 0x5FEA2D, 0x7527BA, 0xC7EBE5,
+        0xF17B3D, 0x0739F7, 0x8A5292, 0xEA6BFB, 0x5FB11F, 0x8D5D08,
+        0x560330, 0x46FC7B, 0x6BABF0, 0xCFBC20, 0x9AF436, 0x1DA9E3,
+        0x91615E, 0xE61B08, 0x659985, 0x5F14A0, 0x68408D, 0xFFD880,
+        0x4D7327, 0x310606, 0x1556CA, 0x73A8C9, 0x60E27B, 0xC08C6B,
+};
+
+#ifdef __STDC__
+static const int npio2_hw[] = {
+#else
+static int npio2_hw[] = {
+#endif
+        0x3FF921FB, 0x400921FB, 0x4012D97C, 0x401921FB, 0x401F6A7A, 0x4022D97C,
+        0x4025FDBB, 0x402921FB, 0x402C463A, 0x402F6A7A, 0x4031475C, 0x4032D97C,
+        0x40346B9C, 0x4035FDBB, 0x40378FDB, 0x403921FB, 0x403AB41B, 0x403C463A,
+        0x403DD85A, 0x403F6A7A, 0x40407E4C, 0x4041475C, 0x4042106C, 0x4042D97C,
+        0x4043A28C, 0x40446B9C, 0x404534AC, 0x4045FDBB, 0x4046C6CB, 0x40478FDB,
+        0x404858EB, 0x404921FB,
+};
+
+/*
+ * invpio2:  53 bits of 2/pi
+ * pio2_1:   first  33 bit of pi/2
+ * pio2_1t:  pi/2 - pio2_1
+ * pio2_2:   second 33 bit of pi/2
+ * pio2_2t:  pi/2 - (pio2_1+pio2_2)
+ * pio2_3:   third  33 bit of pi/2
+ * pio2_3t:  pi/2 - (pio2_1+pio2_2+pio2_3)
+ */
+
+#ifdef __STDC__
+static const double
+#else
+static double
+#endif
+//zero =  0.00000000000000000000e+00, /* 0x00000000, 0x00000000 */
+//half =  5.00000000000000000000e-01, /* 0x3FE00000, 0x00000000 */
+//two24 =  1.67772160000000000000e+07, /* 0x41700000, 0x00000000 */
+invpio2 =  6.36619772367581382433e-01, /* 0x3FE45F30, 0x6DC9C883 */
+pio2_1  =  1.57079632673412561417e+00, /* 0x3FF921FB, 0x54400000 */
+pio2_1t =  6.07710050650619224932e-11, /* 0x3DD0B461, 0x1A626331 */
+pio2_2  =  6.07710050630396597660e-11, /* 0x3DD0B461, 0x1A600000 */
+pio2_2t =  2.02226624879595063154e-21, /* 0x3BA3198A, 0x2E037073 */
+pio2_3  =  2.02226624871116645580e-21, /* 0x3BA3198A, 0x2E000000 */
+pio2_3t =  8.47842766036889956997e-32; /* 0x397B839A, 0x252049C1 */
+
+/*
+* Definitions generated from Newton
+*/
+typedef double bmx055xAcceleration;
+
+#ifdef __STDC__
+int __ieee754_rem_pio2(bmx055xAcceleration x, bmx055xAcceleration *y)
+#else
+int __ieee754_rem_pio2(x,y)
+        bmx055xAcceleration x,y[];
+#endif
+{
+    double z,w,t,r,fn;
+    double tx[3];
+    int e0,i,j,nx,n,ix,hx;
+
+    hx = __HI(x);		/* high word of x */
+    ix = hx&0x7fffffff;
+    if(ix<=0x3fe921fb)   /* |x| ~<= pi/4 , no need for reduction */
+    {y[0] = x; y[1] = 0; return 0;}
+    if(ix<0x4002d97c) {  /* |x| < 3pi/4, special case with n=+-1 */
+        if(hx>0) {
+            z = x - pio2_1;
+            if(ix!=0x3ff921fb) { 	/* 33+53 bit pi is good enough */
+                y[0] = z - pio2_1t;
+                y[1] = (z-y[0])-pio2_1t;
+            } else {		/* near pi/2, use 33+33+53 bit pi */
+                z -= pio2_2;
+                y[0] = z - pio2_2t;
+                y[1] = (z-y[0])-pio2_2t;
+            }
+            return 1;
+        } else {	/* negative x */
+            z = x + pio2_1;
+            if(ix!=0x3ff921fb) { 	/* 33+53 bit pi is good enough */
+                y[0] = z + pio2_1t;
+                y[1] = (z-y[0])+pio2_1t;
+            } else {		/* near pi/2, use 33+33+53 bit pi */
+                z += pio2_2;
+                y[0] = z + pio2_2t;
+                y[1] = (z-y[0])+pio2_2t;
+            }
+            return -1;
+        }
+    }
+    if(ix<=0x413921fb) { /* |x| ~<= 2^19*(pi/2), medium size */
+        t  = fabs(x);
+        n  = (int) (t*invpio2+half);
+        fn = (double)n;
+        r  = t-fn*pio2_1;
+        w  = fn*pio2_1t;	/* 1st round good to 85 bit */
+        if(n<32&&ix!=npio2_hw[n-1]) {
+            y[0] = r-w;	/* quick check no cancellation */
+        } else {
+            j  = ix>>20;
+            y[0] = r-w;
+            i = j-(((__HI(y[0]))>>20)&0x7ff);
+            if(i>16) {  /* 2nd iteration needed, good to 118 */
+                t  = r;
+                w  = fn*pio2_2;
+                r  = t-w;
+                w  = fn*pio2_2t-((t-r)-w);
+                y[0] = r-w;
+                i = j-(((__HI(y[0]))>>20)&0x7ff);
+                if(i>49)  {	/* 3rd iteration need, 151 bits acc */
+                    t  = r;	/* will cover all possible cases */
+                    w  = fn*pio2_3;
+                    r  = t-w;
+                    w  = fn*pio2_3t-((t-r)-w);
+                    y[0] = r-w;
+                }
+            }
+        }
+        y[1] = (r-y[0])-w;
+        if(hx<0) 	{y[0] = -y[0]; y[1] = -y[1]; return -n;}
+        else	 return n;
+    }
+    /* 
+     * all other (large) arguments
+     */
+    if(ix>=0x7ff00000) {		/* x is inf or NaN */
+        y[0]=y[1]=x-x; return 0;
+    }
+    /* set z = scalbn(|x|,ilogb(x)-23) */
+    __LO(z) = __LO(x);
+    e0 	= (ix>>20)-1046;	/* e0 = ilogb(z)-23; */
+    __HI(z) = ix - (e0<<20);
+    for(i=0;i<2;i++) {
+        tx[i] = (double)((int)(z));
+        z     = (z-tx[i])*two24;
+    }
+    tx[2] = z;
+    nx = 3;
+    while(tx[nx-1]==zero) nx--;	/* skip zero term */
+    n  =  __kernel_rem_pio2(tx,y,e0,nx,2,two_over_pi);
+    if(hx<0) {y[0] = -y[0]; y[1] = -y[1]; return -n;}
+    return n;
+}
+
+#endif

--- a/applications/newton/llvm-ir/c-files/e_acosh.c
+++ b/applications/newton/llvm-ir/c-files/e_acosh.c
@@ -48,6 +48,9 @@ double __ieee754_acosh(x)
         bmx055xAcceleration x;
 #endif
 {
+#ifdef ASSUME
+    __builtin_assume(x > -16 && x < 16);
+#endif
     double t;
     int hx;
     hx = __HI(x);
@@ -68,3 +71,99 @@ double __ieee754_acosh(x)
         return log1p(t+sqrt(2.0*t+t*t));
     }
 }
+
+// clang ../c-files/e_acosh.c -D DEBUG -D ASSUME -O3 -o e_acosh_assume -lm
+#ifdef DEBUG
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define iteration_num 500000
+
+typedef struct timespec timespec;
+timespec diff(timespec start, timespec end)
+{
+    timespec temp;
+    if ((end.tv_nsec-start.tv_nsec)<0) {
+        temp.tv_sec = end.tv_sec-start.tv_sec-1;
+        temp.tv_nsec = 1000000000+end.tv_nsec-start.tv_nsec;
+    } else {
+        temp.tv_sec = end.tv_sec-start.tv_sec;
+        temp.tv_nsec = end.tv_nsec-start.tv_nsec;
+    }
+    return temp;
+}
+
+timespec sum(timespec t1, timespec t2) {
+    timespec temp;
+    if (t1.tv_nsec + t2.tv_nsec >= 1000000000) {
+        temp.tv_sec = t1.tv_sec + t2.tv_sec + 1;
+        temp.tv_nsec = t1.tv_nsec + t2.tv_nsec - 1000000000;
+    } else {
+        temp.tv_sec = t1.tv_sec + t2.tv_sec;
+        temp.tv_nsec = t1.tv_nsec + t2.tv_nsec;
+    }
+    return temp;
+}
+
+void printTimeSpec(timespec t, const char* prefix) {
+    printf("%s: %d.%09d\n", prefix, (int)t.tv_sec, (int)t.tv_nsec);
+}
+
+timespec tic( )
+{
+    timespec start_time;
+    clock_gettime(CLOCK_REALTIME, &start_time);
+    return start_time;
+}
+
+void toc( timespec* start_time, const char* prefix )
+{
+    timespec current_time;
+    clock_gettime(CLOCK_REALTIME, &current_time);
+    printTimeSpec( diff( *start_time, current_time ), prefix );
+    *start_time = current_time;
+}
+
+/*
+ * random floating point, [min, max]
+ * */
+static bmx055xAcceleration
+randomDouble(bmx055xAcceleration min, bmx055xAcceleration max)
+{
+    bmx055xAcceleration randDbValue = min + 1.0 * rand() / RAND_MAX * (max - min);
+    return randDbValue;
+}
+
+int main(int argc, char** argv) {
+    double parameters[2];
+    char *pEnd;
+    if (argc == 3) {
+        for (size_t idx = 0; idx < argc - 1; idx++) {
+            parameters[idx] = strtod(argv[idx + 1], &pEnd);
+        }
+    } else {
+        parameters[0] = 3.0;
+        parameters[1] = 10.0;
+    }
+    double result[iteration_num];
+    bmx055xAcceleration xOps[iteration_num];
+    for (size_t idx = 0; idx < iteration_num; idx++) {
+        xOps[idx] = randomDouble(parameters[0], parameters[1]);
+    }
+
+    timespec timer = tic();
+    for (size_t idx = 0; idx < iteration_num; idx++) {
+        result[idx] = __ieee754_acosh(xOps[idx]);
+    }
+
+    toc(&timer, "computation delay");
+
+    printf("results: %f\t%f\t%f\t%f\t%f\n", result[0], result[1], result[2], result[3], result[4]);
+
+    return 0;
+}
+#endif

--- a/applications/newton/llvm-ir/c-files/e_exp.c
+++ b/applications/newton/llvm-ir/c-files/e_exp.c
@@ -109,6 +109,9 @@ double __ieee754_exp(x)	/* default IEEE double exp */
         bmx055xAcceleration x;
 #endif
 {
+#ifdef ASSUME
+    __builtin_assume(x > -16 && x < 16);
+#endif
     double y,hi,lo,c,t;
     int k,xsb;
     unsigned hx;
@@ -158,3 +161,99 @@ double __ieee754_exp(x)	/* default IEEE double exp */
         return y*twom1000;
     }
 }
+
+// clang ../c-files/e_exp.c -D DEBUG -D ASSUME -O3 -o e_exp_assume
+#ifdef DEBUG
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define iteration_num 500000
+
+typedef struct timespec timespec;
+timespec diff(timespec start, timespec end)
+{
+    timespec temp;
+    if ((end.tv_nsec-start.tv_nsec)<0) {
+        temp.tv_sec = end.tv_sec-start.tv_sec-1;
+        temp.tv_nsec = 1000000000+end.tv_nsec-start.tv_nsec;
+    } else {
+        temp.tv_sec = end.tv_sec-start.tv_sec;
+        temp.tv_nsec = end.tv_nsec-start.tv_nsec;
+    }
+    return temp;
+}
+
+timespec sum(timespec t1, timespec t2) {
+    timespec temp;
+    if (t1.tv_nsec + t2.tv_nsec >= 1000000000) {
+        temp.tv_sec = t1.tv_sec + t2.tv_sec + 1;
+        temp.tv_nsec = t1.tv_nsec + t2.tv_nsec - 1000000000;
+    } else {
+        temp.tv_sec = t1.tv_sec + t2.tv_sec;
+        temp.tv_nsec = t1.tv_nsec + t2.tv_nsec;
+    }
+    return temp;
+}
+
+void printTimeSpec(timespec t, const char* prefix) {
+    printf("%s: %d.%09d\n", prefix, (int)t.tv_sec, (int)t.tv_nsec);
+}
+
+timespec tic( )
+{
+    timespec start_time;
+    clock_gettime(CLOCK_REALTIME, &start_time);
+    return start_time;
+}
+
+void toc( timespec* start_time, const char* prefix )
+{
+    timespec current_time;
+    clock_gettime(CLOCK_REALTIME, &current_time);
+    printTimeSpec( diff( *start_time, current_time ), prefix );
+    *start_time = current_time;
+}
+
+/*
+ * random floating point, [min, max]
+ * */
+static bmx055xAcceleration
+randomDouble(bmx055xAcceleration min, bmx055xAcceleration max)
+{
+    bmx055xAcceleration randDbValue = min + 1.0 * rand() / RAND_MAX * (max - min);
+    return randDbValue;
+}
+
+int main(int argc, char** argv) {
+    double parameters[2];
+    char *pEnd;
+    if (argc == 3) {
+        for (size_t idx = 0; idx < argc - 1; idx++) {
+            parameters[idx] = strtod(argv[idx + 1], &pEnd);
+        }
+    } else {
+        parameters[0] = 3.0;
+        parameters[1] = 10.0;
+    }
+    double result[iteration_num];
+    bmx055xAcceleration xOps[iteration_num];
+    for (size_t idx = 0; idx < iteration_num; idx++) {
+        xOps[idx] = randomDouble(parameters[0], parameters[1]);
+    }
+
+    timespec timer = tic();
+    for (size_t idx = 0; idx < iteration_num; idx++) {
+        result[idx] = __ieee754_exp(xOps[idx]);
+    }
+
+    toc(&timer, "computation delay");
+
+    printf("results: %f\t%f\t%f\t%f\t%f\n", result[0], result[1], result[2], result[3], result[4]);
+
+    return 0;
+}
+#endif

--- a/applications/newton/llvm-ir/c-files/e_y0.c
+++ b/applications/newton/llvm-ir/c-files/e_y0.c
@@ -56,7 +56,13 @@
  *	3. Special cases: y0(0)=-inf, y0(x<0)=NaN, y0(inf)=0.
  */
 
+#define IEEE_IMPLEMENT_SIN_COS
+
 #include "fdlibm.h"
+#ifdef IEEE_IMPLEMENT_SIN_COS
+#include "s_sin.c"
+#include "s_cos.c"
+#endif
 
 #ifdef __STDC__
 static double pzero(double), qzero(double);
@@ -70,7 +76,9 @@ static const double
 static double
 #endif
         huge 	= 1e300,
+#ifndef IEEE_IMPLEMENT_SIN_COS
         one	= 1.0,
+#endif
         invsqrtpi=  5.64189583547756279280e-01, /* 0x3FE20DD7, 0x50429B6D */
 tpi      =  6.36619772367581382433e-01, /* 0x3FE45F30, 0x6DC9C883 */
 /* R0/S0 on [0, 2.00] */
@@ -83,7 +91,9 @@ S02  =  1.16926784663337450260e-04, /* 0x3F1EA6D2, 0xDD57DBF4 */
 S03  =  5.13546550207318111446e-07, /* 0x3EA13B54, 0xCE84D5A9 */
 S04  =  1.16614003333790000205e-09; /* 0x3E1408BC, 0xF4745D8F */
 
+#ifndef IEEE_IMPLEMENT_SIN_COS
 static double zero = 0.0;
+#endif
 
 #ifdef __STDC__
 double __ieee754_j0(double x)

--- a/applications/newton/llvm-ir/c-files/fdlibm.h
+++ b/applications/newton/llvm-ir/c-files/fdlibm.h
@@ -10,6 +10,8 @@
  * ====================================================
  */
 
+#ifndef FD_LIBM
+#define FD_LIBM
 /* Sometimes it's necessary to define __LITTLE_ENDIAN explicitly
    but these catch some common cases. */
 #include "th_cfg.h"
@@ -214,3 +216,5 @@ extern double __kernel_sin __P((double,double,int));
 extern double __kernel_cos __P((double,double));
 extern double __kernel_tan __P((double,double,int));
 extern int    __kernel_rem_pio2 __P((double*,double*,int,int,int,const int*));
+
+#endif

--- a/applications/newton/llvm-ir/c-files/k_cos.c
+++ b/applications/newton/llvm-ir/c-files/k_cos.c
@@ -1,0 +1,97 @@
+
+/* @(#)k_cos.c 1.4 96/03/07 */
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunSoft, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice 
+ * is preserved.
+ * ====================================================
+ */
+
+/*
+ * __kernel_cos( x,  y )
+ * kernel cos function on [-pi/4, pi/4], pi/4 ~ 0.785398164
+ * Input x is assumed to be bounded by ~pi/4 in magnitude.
+ * Input y is the tail of x. 
+ *
+ * Algorithm
+ *	1. Since cos(-x) = cos(x), we need only to consider positive x.
+ *	2. if x < 2^-27 (hx<0x3e400000 0), return 1 with inexact if x!=0.
+ *	3. cos(x) is approximated by a polynomial of degree 14 on
+ *	   [0,pi/4]
+ *		  	                 4            14
+ *	   	cos(x) ~ 1 - x*x/2 + C1*x + ... + C6*x
+ *	   where the Remes error is
+ *	
+ * 	|              2     4     6     8     10    12     14 |     -58
+ * 	|cos(x)-(1-.5*x +C1*x +C2*x +C3*x +C4*x +C5*x  +C6*x  )| <= 2
+ * 	|    					               | 
+ * 
+ * 	               4     6     8     10    12     14 
+ *	4. let r = C1*x +C2*x +C3*x +C4*x +C5*x  +C6*x  , then
+ *	       cos(x) = 1 - x*x/2 + r
+ *	   since cos(x+y) ~ cos(x) - sin(x)*y 
+ *			  ~ cos(x) - x*y,
+ *	   a correction term is necessary in cos(x) and hence
+ *		cos(x+y) = 1 - (x*x/2 - (r - x*y))
+ *	   For better accuracy when x > 0.3, let qx = |x|/4 with
+ *	   the last 32 bits mask off, and if x > 0.78125, let qx = 0.28125.
+ *	   Then
+ *		cos(x+y) = (1-qx) - ((x*x/2-qx) - (r-x*y)).
+ *	   Note that 1-qx and (x*x/2-qx) is EXACT here, and the
+ *	   magnitude of the latter is at least a quarter of x*x/2,
+ *	   thus, reducing the rounding error in the subtraction.
+ */
+
+#ifndef K_COS_C
+#define K_COS_C
+
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double 
+#else
+static double 
+#endif
+one =  1.00000000000000000000e+00, /* 0x3FF00000, 0x00000000 */
+C1  =  4.16666666666666019037e-02, /* 0x3FA55555, 0x5555554C */
+C2  = -1.38888888888741095749e-03, /* 0xBF56C16C, 0x16C15177 */
+C3  =  2.48015872894767294178e-05, /* 0x3EFA01A0, 0x19CB1590 */
+C4  = -2.75573143513906633035e-07, /* 0xBE927E4F, 0x809C52AD */
+C5  =  2.08757232129817482790e-09, /* 0x3E21EE9E, 0xBDB4B1C4 */
+C6  = -1.13596475577881948265e-11; /* 0xBDA8FAE9, 0xBE8838D4 */
+
+#ifdef __STDC__
+	double __kernel_cos(double x, double y)
+#else
+	double __kernel_cos(x, y)
+	double x,y;
+#endif
+{
+	double a,hz,z,r,qx;
+	int ix;
+	ix = __HI(x)&0x7fffffff;	/* ix = |x|'s high word*/
+	if(ix<0x3e400000) {			/* if x < 2**27 */
+	    if(((int)x)==0) return one;		/* generate inexact */
+	}
+	z  = x*x;
+	r  = z*(C1+z*(C2+z*(C3+z*(C4+z*(C5+z*C6)))));
+	if(ix < 0x3FD33333) 			/* if |x| < 0.3 */ 
+	    return one - (0.5*z - (z*r - x*y));
+	else {
+	    if(ix > 0x3fe90000) {		/* x > 0.78125 */
+		qx = 0.28125;
+	    } else {
+	        __HI(qx) = ix-0x00200000;	/* x/4 */
+	        __LO(qx) = 0;
+	    }
+	    hz = 0.5*z-qx;
+	    a  = one-qx;
+	    return a - (hz - (z*r-x*y));
+	}
+}
+
+#endif

--- a/applications/newton/llvm-ir/c-files/k_sin.c
+++ b/applications/newton/llvm-ir/c-files/k_sin.c
@@ -1,0 +1,78 @@
+
+/* @(#)k_sin.c 1.3 95/01/18 */
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunSoft, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice 
+ * is preserved.
+ * ====================================================
+ */
+
+/* __kernel_sin( x, y, iy)
+ * kernel sin function on [-pi/4, pi/4], pi/4 ~ 0.7854
+ * Input x is assumed to be bounded by ~pi/4 in magnitude.
+ * Input y is the tail of x.
+ * Input iy indicates whether y is 0. (if iy=0, y assume to be 0). 
+ *
+ * Algorithm
+ *	1. Since sin(-x) = -sin(x), we need only to consider positive x. 
+ *	2. if x < 2^-27 (hx<0x3e400000 0), return x with inexact if x!=0.
+ *	3. sin(x) is approximated by a polynomial of degree 13 on
+ *	   [0,pi/4]
+ *		  	         3            13
+ *	   	sin(x) ~ x + S1*x + ... + S6*x
+ *	   where
+ *	
+ * 	|sin(x)         2     4     6     8     10     12  |     -58
+ * 	|----- - (1+S1*x +S2*x +S3*x +S4*x +S5*x  +S6*x   )| <= 2
+ * 	|  x 					           | 
+ * 
+ *	4. sin(x+y) = sin(x) + sin'(x')*y
+ *		    ~ sin(x) + (1-x*x/2)*y
+ *	   For better accuracy, let 
+ *		     3      2      2      2      2
+ *		r = x *(S2+x *(S3+x *(S4+x *(S5+x *S6))))
+ *	   then                   3    2
+ *		sin(x) = x + (S1*x + (x *(r-y/2)+y))
+ */
+
+#ifndef K_SIN_C
+#define K_SIN_C
+#include "fdlibm.h"
+
+#ifdef __STDC__
+static const double 
+#else
+static double 
+#endif
+half =  5.00000000000000000000e-01, /* 0x3FE00000, 0x00000000 */
+S1  = -1.66666666666666324348e-01, /* 0xBFC55555, 0x55555549 */
+S2  =  8.33333333332248946124e-03, /* 0x3F811111, 0x1110F8A6 */
+S3  = -1.98412698298579493134e-04, /* 0xBF2A01A0, 0x19C161D5 */
+S4  =  2.75573137070700676789e-06, /* 0x3EC71DE3, 0x57B1FE7D */
+S5  = -2.50507602534068634195e-08, /* 0xBE5AE5E6, 0x8A2B9CEB */
+S6  =  1.58969099521155010221e-10; /* 0x3DE5D93A, 0x5ACFD57C */
+
+#ifdef __STDC__
+	double __kernel_sin(double x, double y, int iy)
+#else
+	double __kernel_sin(x, y, iy)
+	double x,y; int iy;		/* iy=0 if y is zero */
+#endif
+{
+	double z,r,v;
+	int ix;
+	ix = __HI(x)&0x7fffffff;	/* high word of x */
+	if(ix<0x3e400000)			/* |x| < 2**-27 */
+	   {if((int)x==0) return x;}		/* generate inexact */
+	z	=  x*x;
+	v	=  z*x;
+	r	=  S2+z*(S3+z*(S4+z*(S5+z*S6)));
+	if(iy==0) return x+v*(S1+z*r);
+	else      return x-((z*(half*y-v*r)-y)-v*S1);
+}
+
+#endif

--- a/applications/newton/llvm-ir/c-files/s_cos.c
+++ b/applications/newton/llvm-ir/c-files/s_cos.c
@@ -1,0 +1,81 @@
+
+/* @(#)s_cos.c 1.3 95/01/18 */
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunSoft, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice 
+ * is preserved.
+ * ====================================================
+ */
+
+/* cos(x)
+ * Return cosine function of x.
+ *
+ * kernel function:
+ *	__kernel_sin		... sine function on [-pi/4,pi/4]
+ *	__kernel_cos		... cosine function on [-pi/4,pi/4]
+ *	__ieee754_rem_pio2	... argument reduction routine
+ *
+ * Method.
+ *      Let S,C and T denote the sin, cos and tan respectively on 
+ *	[-PI/4, +PI/4]. Reduce the argument x to y1+y2 = x-k*pi/2 
+ *	in [-pi/4 , +pi/4], and let n = k mod 4.
+ *	We have
+ *
+ *          n        sin(x)      cos(x)        tan(x)
+ *     ----------------------------------------------------------
+ *	    0	       S	   C		 T
+ *	    1	       C	  -S		-1/T
+ *	    2	      -S	  -C		 T
+ *	    3	      -C	   S		-1/T
+ *     ----------------------------------------------------------
+ *
+ * Special cases:
+ *      Let trig be any of sin, cos, or tan.
+ *      trig(+-INF)  is NaN, with signals;
+ *      trig(NaN)    is that NaN;
+ *
+ * Accuracy:
+ *	TRIG(x) returns trig(x) nearly rounded 
+ */
+
+#include "fdlibm.h"
+#include "k_sin.c"
+#include "k_cos.c"
+#include "called_rem_pio2.c"
+
+#ifdef __STDC__
+	double cos(double x)
+#else
+	double cos(x)
+	double x;
+#endif
+{
+	double y[2],z=0.0;
+	int n, ix;
+
+    /* High word of x. */
+	ix = __HI(x);
+
+    /* |x| ~< pi/4 */
+	ix &= 0x7fffffff;
+	if(ix <= 0x3fe921fb) return __kernel_cos(x,z);
+
+    /* cos(Inf or NaN) is NaN */
+	else if (ix>=0x7ff00000) return x-x;
+
+    /* argument reduction needed */
+	else {
+	    n = __ieee754_rem_pio2(x,y);
+	    switch(n&3) {
+		case 0: return  __kernel_cos(y[0],y[1]);
+		case 1: return -__kernel_sin(y[0],y[1],1);
+		case 2: return -__kernel_cos(y[0],y[1]);
+		default:
+		        return  __kernel_sin(y[0],y[1],1);
+	    }
+	}
+}

--- a/applications/newton/llvm-ir/c-files/s_sin.c
+++ b/applications/newton/llvm-ir/c-files/s_sin.c
@@ -1,0 +1,81 @@
+
+/* @(#)s_sin.c 1.3 95/01/18 */
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunSoft, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice 
+ * is preserved.
+ * ====================================================
+ */
+
+/* sin(x)
+ * Return sine function of x.
+ *
+ * kernel function:
+ *	__kernel_sin		... sine function on [-pi/4,pi/4]
+ *	__kernel_cos		... cose function on [-pi/4,pi/4]
+ *	__ieee754_rem_pio2	... argument reduction routine
+ *
+ * Method.
+ *      Let S,C and T denote the sin, cos and tan respectively on 
+ *	[-PI/4, +PI/4]. Reduce the argument x to y1+y2 = x-k*pi/2 
+ *	in [-pi/4 , +pi/4], and let n = k mod 4.
+ *	We have
+ *
+ *          n        sin(x)      cos(x)        tan(x)
+ *     ----------------------------------------------------------
+ *	    0	       S	   C		 T
+ *	    1	       C	  -S		-1/T
+ *	    2	      -S	  -C		 T
+ *	    3	      -C	   S		-1/T
+ *     ----------------------------------------------------------
+ *
+ * Special cases:
+ *      Let trig be any of sin, cos, or tan.
+ *      trig(+-INF)  is NaN, with signals;
+ *      trig(NaN)    is that NaN;
+ *
+ * Accuracy:
+ *	TRIG(x) returns trig(x) nearly rounded 
+ */
+
+#include "fdlibm.h"
+#include "k_sin.c"
+#include "k_cos.c"
+#include "called_rem_pio2.c"
+
+#ifdef __STDC__
+	double sin(double x)
+#else
+	double sin(x)
+	double x;
+#endif
+{
+	double y[2],z=0.0;
+	int n, ix;
+
+    /* High word of x. */
+	ix = __HI(x);
+
+    /* |x| ~< pi/4 */
+	ix &= 0x7fffffff;
+	if(ix <= 0x3fe921fb) return __kernel_sin(x,z,0);
+
+    /* sin(Inf or NaN) is NaN */
+	else if (ix>=0x7ff00000) return x-x;
+
+    /* argument reduction needed */
+	else {
+	    n = __ieee754_rem_pio2(x,y);
+	    switch(n&3) {
+		case 0: return  __kernel_sin(y[0],y[1],1);
+		case 1: return  __kernel_cos(y[0],y[1]);
+		case 2: return -__kernel_sin(y[0],y[1],1);
+		default:
+			return -__kernel_cos(y[0],y[1]);
+	    }
+	}
+}

--- a/applications/newton/llvm-ir/c-files/sincosf.c
+++ b/applications/newton/llvm-ir/c-files/sincosf.c
@@ -43,6 +43,9 @@ typedef double bmx055xAcceleration;
 void
 libc_sincosf (bmx055xAcceleration y, float *sinp, float *cosp)
 {
+#ifdef ASSUME
+    __builtin_assume(y > -16 && y < 16);
+#endif
     double x = y;
     double s;
     int n;
@@ -105,10 +108,101 @@ libc_sincosf (bmx055xAcceleration y, float *sinp, float *cosp)
     }
 }
 
-//#endif
+// clang ../c-files/sincosf.c -D DEBUG -D ASSUME -O3 -o sincosf_assume -lm
+#ifdef DEBUG
 
-//int main() {
-//    float sinp, cosp;
-//    libc_sincosf (35.85, &sinp, &cosp);
-//    printf("sinp: %f, cosp: %f\n", sinp, cosp);
-//}
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define iteration_num 500000
+
+typedef struct timespec timespec;
+timespec diff(timespec start, timespec end)
+{
+    timespec temp;
+    if ((end.tv_nsec-start.tv_nsec)<0) {
+        temp.tv_sec = end.tv_sec-start.tv_sec-1;
+        temp.tv_nsec = 1000000000+end.tv_nsec-start.tv_nsec;
+    } else {
+        temp.tv_sec = end.tv_sec-start.tv_sec;
+        temp.tv_nsec = end.tv_nsec-start.tv_nsec;
+    }
+    return temp;
+}
+
+timespec sum(timespec t1, timespec t2) {
+    timespec temp;
+    if (t1.tv_nsec + t2.tv_nsec >= 1000000000) {
+        temp.tv_sec = t1.tv_sec + t2.tv_sec + 1;
+        temp.tv_nsec = t1.tv_nsec + t2.tv_nsec - 1000000000;
+    } else {
+        temp.tv_sec = t1.tv_sec + t2.tv_sec;
+        temp.tv_nsec = t1.tv_nsec + t2.tv_nsec;
+    }
+    return temp;
+}
+
+void printTimeSpec(timespec t, const char* prefix) {
+    printf("%s: %d.%09d\n", prefix, (int)t.tv_sec, (int)t.tv_nsec);
+}
+
+timespec tic( )
+{
+    timespec start_time;
+    clock_gettime(CLOCK_REALTIME, &start_time);
+    return start_time;
+}
+
+void toc( timespec* start_time, const char* prefix )
+{
+    timespec current_time;
+    clock_gettime(CLOCK_REALTIME, &current_time);
+    printTimeSpec( diff( *start_time, current_time ), prefix );
+    *start_time = current_time;
+}
+
+/*
+ * random floating point, [min, max]
+ * */
+static bmx055xAcceleration
+randomDouble(bmx055xAcceleration min, bmx055xAcceleration max)
+{
+    bmx055xAcceleration randDbValue = min + 1.0 * rand() / RAND_MAX * (max - min);
+    return randDbValue;
+}
+
+int main(int argc, char** argv) {
+    double parameters[2];
+    char *pEnd;
+    if (argc == 3) {
+        for (size_t idx = 0; idx < argc - 1; idx++) {
+            parameters[idx] = strtod(argv[idx + 1], &pEnd);
+        }
+    } else {
+        parameters[0] = 3.0;
+        parameters[1] = 10.0;
+    }
+    double result[iteration_num];
+    bmx055xAcceleration xOps[iteration_num];
+    for (size_t idx = 0; idx < iteration_num; idx++) {
+        xOps[idx] = randomDouble(parameters[0], parameters[1]);
+    }
+
+    timespec timer = tic();
+    float sinp, cosp;
+    for (size_t idx = 0; idx < iteration_num; idx++) {
+        sinp = cosp = 0;
+        libc_sincosf(xOps[idx], &sinp, &cosp);
+        result[idx] = sinp;
+    }
+
+    toc(&timer, "computation delay");
+
+    printf("results: %f\t%f\t%f\t%f\t%f\n", result[0], result[1], result[2], result[3], result[4]);
+
+    return 0;
+}
+#endif

--- a/applications/newton/llvm-ir/c-files/vec_add.c
+++ b/applications/newton/llvm-ir/c-files/vec_add.c
@@ -8,52 +8,7 @@
 #include <sys/time.h>
 #include <time.h>
 
-typedef struct timespec timespec;
-timespec diff(timespec start, timespec end)
-{
-    timespec temp;
-    if ((end.tv_nsec-start.tv_nsec)<0) {
-        temp.tv_sec = end.tv_sec-start.tv_sec-1;
-        temp.tv_nsec = 1000000000+end.tv_nsec-start.tv_nsec;
-    } else {
-        temp.tv_sec = end.tv_sec-start.tv_sec;
-        temp.tv_nsec = end.tv_nsec-start.tv_nsec;
-    }
-    return temp;
-}
-
-timespec sum(timespec t1, timespec t2) {
-    timespec temp;
-    if (t1.tv_nsec + t2.tv_nsec >= 1000000000) {
-        temp.tv_sec = t1.tv_sec + t2.tv_sec + 1;
-        temp.tv_nsec = t1.tv_nsec + t2.tv_nsec - 1000000000;
-    } else {
-        temp.tv_sec = t1.tv_sec + t2.tv_sec;
-        temp.tv_nsec = t1.tv_nsec + t2.tv_nsec;
-    }
-    return temp;
-}
-
-void printTimeSpec(timespec t, const char* prefix) {
-    printf("%s: %d.%09d\n", prefix, (int)t.tv_sec, (int)t.tv_nsec);
-}
-
-timespec tic( )
-{
-    timespec start_time;
-    clock_gettime(CLOCK_REALTIME, &start_time);
-    return start_time;
-}
-
-void toc( timespec* start_time, const char* prefix )
-{
-    timespec current_time;
-    clock_gettime(CLOCK_REALTIME, &current_time);
-    printTimeSpec( diff( *start_time, current_time ), prefix );
-    *start_time = current_time;
-}
-
-typedef int32_t bmx055fAcceleration;
+typedef float bmx055fAcceleration;
 
 #define NUM 102400
 
@@ -65,16 +20,16 @@ void vec_add(bmx055fAcceleration *vec_A, bmx055fAcceleration *vec_B, bmx055fAcce
 }
 
 int main() {
-    int32_t x[NUM], y[NUM], z[NUM];
+    float x[NUM], y[NUM], z[NUM];
     for (size_t idx = 0; idx < NUM; idx++) {
         x[idx] = rand() % INT8_MAX;
         y[idx] = rand() % INT8_MAX;
     }
-    timespec timer = tic();
+//    timespec timer = tic();
     vec_add(x, y, z, NUM);
-    toc(&timer, "computation delay");
+//    toc(&timer, "computation delay");
     for (size_t idx = 0; idx < NUM; idx++) {
-        printf("value of z[%d]=%d, ", idx, z[idx]);
+        printf("value of z[%d]=%f, ", idx, z[idx]);
     }
     return 0;
 }

--- a/applications/newton/llvm-ir/fusion/Makefile
+++ b/applications/newton/llvm-ir/fusion/Makefile
@@ -17,7 +17,7 @@ TARGET_FLAG=-target aarch64
 endif
 
 NEWTON_BIN_DIR = ../../../../src/newton
-newton_opt_fn = ./newton-linux-EN --llvm-ir=../../applications/newton/llvm-ir/fusion/fusion.ll --llvm-ir-liveness-check ../../applications/newton/sensors/BMX055.nt
+newton_opt_fn = ./newton-linux-EN --llvm-ir=../../applications/newton/llvm-ir/fusion/fusion.ll --llvm-ir-liveness-check --llvm-ir-enable-overload --llvm-ir-enable-builtin-assume ../../applications/newton/sensors/BMX055.nt
 
 all: default
 

--- a/applications/newton/llvm-ir/pedometer/Makefile
+++ b/applications/newton/llvm-ir/pedometer/Makefile
@@ -17,7 +17,7 @@ TARGET_FLAG=-target aarch64
 endif
 
 NEWTON_BIN_DIR = ../../../../src/newton
-newton_opt_fn = ./newton-linux-EN --llvm-ir=../../applications/newton/llvm-ir/pedometer/perf_main.ll --llvm-ir-liveness-check ../../applications/newton/sensors/BMX055.nt
+newton_opt_fn = ./newton-linux-EN --llvm-ir=../../applications/newton/llvm-ir/pedometer/perf_main.ll --llvm-ir-liveness-check --llvm-ir-enable-overload --llvm-ir-enable-builtin-assume ../../applications/newton/sensors/BMX055.nt
 
 all: default
 

--- a/applications/newton/llvm-ir/performance_test/Makefile
+++ b/applications/newton/llvm-ir/performance_test/Makefile
@@ -1,7 +1,7 @@
 ### Makefile to run the optimization and get the performance data automatically ###
 
 ifndef VERBOSE
-	QUIET:=@
+QUIET:=@
 endif
 
 MAKE_CLEAN = make clean
@@ -17,18 +17,21 @@ OUT_S = out.s
 OUT_OBJ = out.o
 OUT_LIB = libout.a
 
+# DEBUG_MODE=true make ...
 ifdef DEBUG_MODE
 CC_OPT_LEVEL = -O0 -g
 else
 CC_OPT_LEVEL = -O3 -Os
 endif
 
+# CROSS_COMPILE=true make ...
 ifdef CROSS_COMPILE
 TARGET_FLAG = -target aarch64
 TARGET_LLC_FLAG = --march=aarch64
 endif
 
 # real-world application configs
+# REAL_APP=true make ...
 ifdef REAL_APP
 NT_FILE = BMX055.nt
 else
@@ -36,13 +39,16 @@ NT_FILE = test.nt
 endif
 
 # auto-quantization configs, FP hardware by default, for Madgwick only currently
+# AUTO_QUANT=true make ...
 ifdef AUTO_QUANT
 DATA_TYPE=INT_DATA_TYPE
 else
 DATA_TYPE=FP_DATA_TYPE
 
+# SOFT_FLOAT_LIB=true make ...
 ifdef SOFT_FLOAT_LIB
 SOFT_FLOAT_LIB=SOFT_FLOAT_LIB
+# SOFT_FLOAT=true make ...
 else ifdef SOFT_FLOAT
 CC_FP_FLAG = -msoft-float
 OPT_FP_FLAG = --float-abi=soft
@@ -50,11 +56,20 @@ endif
 
 endif
 
+# ENABLE_OVERLOAD=true ENABLE_BUILTIN_ASSUME=true make ...
+NEWTON_FLAG=--llvm-ir-liveness-check
+ifdef ENABLE_OVERLOAD
+NEWTON_FLAG+=--llvm-ir-enable-overload
+endif
+ifdef ENABLE_BUILTIN_ASSUME
+NEWTON_FLAG+=--llvm-ir-enable-builtin-assume
+endif
+
 max_opt_fn = opt ../$(1).ll $(OPT_FP_FLAG) -O3 -Os -S -o $(OUT_FILE)
 non_opt_fn = cp ../$(1).ll $(OUT_FILE)
 necessary_opt_fn = opt ../$(1).ll --simplifycfg --instsimplify -S -o $(OUT_FILE)
 
-newton_opt_fn = ./newton-linux-EN --llvm-ir=../../applications/newton/llvm-ir/$(1).ll --llvm-ir-liveness-check ../../applications/newton/sensors/$(NT_FILE)
+newton_opt_fn = ./newton-linux-EN --llvm-ir=../../applications/newton/llvm-ir/$(1).ll $(NEWTON_FLAG) ../../applications/newton/sensors/$(NT_FILE)
 
 compile_main_fn = $(CC) main.c $(TARGET_FLAG) -no-pie -L. -lout -D $(1) $(CC_OPT_LEVEL) -o main_out -lm
 
@@ -259,7 +274,15 @@ endif
 madgwick_opt:
 	cd $(NEWTON_BIN_DIR) && $(call newton_opt_fn,MadgwickAHRSfix)
 	llvm-dis ../MadgwickAHRSfix_output.bc
-	$(call max_opt_fn,MadgwickAHRSfix)
+	$(call max_opt_fn,MadgwickAHRSfix_output)
+
+inferBoundControlFlow_non_opt:
+	$(call max_opt_fn,inferBoundControlFlow)
+
+inferBoundControlFlow_opt:
+	cd $(NEWTON_BIN_DIR) && $(call newton_opt_fn,inferBoundControlFlow)
+	llvm-dis ../inferBoundControlFlow_output.bc
+	$(call max_opt_fn,inferBoundControlFlow_output)
 
 compile_test_madgwick:
 	$(CC) ../test_madgwick.c -D $(DATA_TYPE) $(CC_FP_FLAG) $(TARGET_FLAG) -no-pie -L. -lout $(CC_OPT_LEVEL) -o main_out -lm
@@ -341,6 +364,10 @@ perf_arm_sqrt_q15: clean make_ll arm_sqrt_q15_non_opt compile_lib compile_arm_sq
 perf_arm_sqrt_q15_opt: clean make_ll arm_sqrt_q15_opt compile_lib compile_arm_sqrt_q15
 
 interface_lib: clean make_ll soft_float_api_opt compile_lib
+
+perf_inferBoundControlFlow: clean make_ll inferBoundControlFlow_non_opt compile_lib
+
+perf_inferBoundControlFlow_opt: clean make_ll inferBoundControlFlow_opt compile_lib
 
 auto_test_compile:
 	clang++ auto_test.cpp -g -o auto_test

--- a/applications/newton/llvm-ir/performance_test/plot_bitwise_compare.py
+++ b/applications/newton/llvm-ir/performance_test/plot_bitwise_compare.py
@@ -1,0 +1,93 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.ticker import FuncFormatter
+from matplotlib.ticker import PercentFormatter
+
+
+def bar_plot_groups(labels,
+                    y1,
+                    y2,
+                    y1_label,
+                    y2_label,
+                    ylabel,
+                    title,
+                    save_fig='',
+                    percentage=False):
+    """
+    A simple wrapper for matplotlib's barplot.
+
+    :param labels:
+    :param y1:
+    :param y2:
+    :param ylabel:
+    :param xlabel:
+    :param save_fig:
+    :return:
+    """
+    xlabel = labels + labels
+    x = np.arange(len(xlabel))  # the label locations
+    width = 0.35  # the width of the bars
+
+    plt.rc('text', usetex=True)
+    plt.rc('font', family='serif')
+    plt.rc('font', size=12)
+
+    fig, ax = plt.subplots()
+    # ax.bar(x - width / 2, y1[0:len(x)], width, label=y1_label, color='#c2a4cf')
+    # ax.bar(x + width / 2, y2[0:len(x)], width, label=y2_label, color='#7b3294')
+    ax.bar(x[0:len(labels)] - width / 2, y1[0:len(labels)], width, label="arm "+y1_label, color='#fdb863')
+    ax.bar(x[0:len(labels)] + width / 2, y2[0:len(labels)], width, label="arm "+y2_label, color='#e66101')
+    ax.bar(x[len(labels):] - width / 2, y1[len(labels):], width, label="x86 "+y1_label, color='#c2a4cf')
+    ax.bar(x[len(labels):] + width / 2, y2[len(labels):], width, label="x86 "+y2_label, color='#7b3294')
+
+    # Add some text for labels, title and custom x-axis tick labels, etc.
+    ax.set_ylabel(ylabel)
+    if percentage:
+        ax.yaxis.set_major_formatter(PercentFormatter(1))
+        ax.set_ylim([-0.05, max(max(y1), max(y2))*1.1])
+    else:
+        ax.set_ylim([min(min(y1), min(y2))*0.8, max(max(y1), max(y2))*1.1])
+    ax.set_title(title)
+    ax.set_xticks(x)
+    ax.set_xticklabels(xlabel)
+    ax.legend(prop={'size': 9}, loc='upper right')
+
+    plt.xticks(rotation=45)
+    ax.yaxis.grid()  # horizontal lines
+
+    fig.tight_layout()
+
+    if len(save_fig):
+        plt.savefig(save_fig)
+    else:
+        plt.show()
+
+
+if __name__ == '__main__':
+    labels = ["rem_pio2", "sincosf", "float64_add", "float64_div", "float64_mul"]
+
+    # time speedup
+    arm_without_bitwise = [1.04, 1, 1.25, 1.16, 1.22]
+    arm_with_bitwise = [1.11, 1.39, 2.01, 1.41, 1.33]
+    x86_without_bitwise = [1.07, 1.05, 1.18, 1.06, 1.12]
+    x86_with_bitwise = [1.13, 1.48, 1.47, 1.14, 1.20]
+    y1 = arm_without_bitwise + x86_without_bitwise
+    y2 = arm_with_bitwise + x86_with_bitwise
+
+    bar_plot_groups(labels, y1, y2, 'w/o Bitwise Op Analysis',
+                    'w/ Bitwise Op Analysis', 'Speedup',
+                    'Speedup with/without bitwise operator analysis',
+                    'bitwise_op_time_comparison.png')
+
+    # size reduction
+    arm_without_bitwise = [1-0.71, 1-1, 1-1, 1-0.86, 1-0.89]
+    arm_with_bitwise = [1-0.8, 1-0.92, 1-0.98, 1-0.79, 1-0.98]
+    x86_without_bitwise = [1-0.46, 1-1, 1-1, 1-0.86, 1-0.86]
+    x86_with_bitwise = [1-0.65, 1-0.91, 1-0.99, 1-0.79, 1-0.94]
+    y1 = arm_without_bitwise + x86_without_bitwise
+    y2 = arm_with_bitwise + x86_with_bitwise
+
+    bar_plot_groups(labels, y1, y2, 'w/o Bitwise Op Analysis',
+                    'w/ Bitwise Op Analysis', 'Reduction',
+                    'Size reduction with/without bitwise operator analysis',
+                    'bitwise_op_size_comparison.png', percentage=True)

--- a/applications/newton/llvm-ir/performance_test/test_madgwick_assume.sh
+++ b/applications/newton/llvm-ir/performance_test/test_madgwick_assume.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+
+[ -e assume.log ] && rm assume.log
+
+ASSUME=true lowerBound=-2 upperBound=2 make perf_madgwick >& compile.log
+./main_out -2 2 >> assume.log
+ASSUME=true lowerBound=-4 upperBound=4 make perf_madgwick >& compile.log
+./main_out -4 4 >> assume.log
+ASSUME=true lowerBound=-8 upperBound=8 make perf_madgwick >& compile.log
+./main_out -8 8 >> assume.log
+ASSUME=true lowerBound=-16 upperBound=16 make perf_madgwick >& compile.log
+./main_out -16 16 >> assume.log
+ASSUME=true lowerBound=-125 upperBound=125 make perf_madgwick >& compile.log
+./main_out -125 125 >> assume.log
+ASSUME=true lowerBound=-40 upperBound=110 make perf_madgwick >& compile.log
+./main_out -40 110 >> assume.log
+ASSUME=true lowerBound=-55 upperBound=150 make perf_madgwick >& compile.log
+./main_out -55 150 >> assume.log
+ASSUME=true lowerBound=0 upperBound=100 make perf_madgwick >& compile.log
+./main_out 0 100 >> assume.log
+ASSUME=true lowerBound=0 upperBound=70 make perf_madgwick >& compile.log
+./main_out 0 70 >> assume.log
+ASSUME=true lowerBound=260 upperBound=1260 make perf_madgwick >& compile.log
+./main_out 260 1260 >> assume.log
+ASSUME=true lowerBound=10 upperBound=45 make perf_madgwick >& compile.log
+./main_out 10 45 >> assume.log
+ASSUME=true lowerBound=-55 upperBound=125 make perf_madgwick >& compile.log
+./main_out -55 125 >> assume.log
+ASSUME=true lowerBound=20 upperBound=80 make perf_madgwick >& compile.log
+./main_out 20 80 >> assume.log
+ASSUME=true lowerBound=0 upperBound=50 make perf_madgwick >& compile.log
+./main_out 0 50 >> assume.log
+ASSUME=true lowerBound=-0.2 upperBound=2 make perf_madgwick >& compile.log
+./main_out -0.2 2 >> assume.log
+ASSUME=true lowerBound=30 upperBound=130 make perf_madgwick >& compile.log
+./main_out 30 130 >> assume.log
+ASSUME=true lowerBound=1 upperBound=200 make perf_madgwick >& compile.log
+./main_out 1 200 >> assume.log
+echo "-----------------without assume-----------------" >> assume.log
+make perf_madgwick >& compile.log
+# shellcheck disable=SC2129
+./main_out -2 2 >> assume.log
+./main_out -4 4 >> assume.log
+./main_out -8 8 >> assume.log
+./main_out -16 16 >> assume.log
+./main_out -125 125 >> assume.log
+./main_out -40 110 >> assume.log
+./main_out -55 150 >> assume.log
+./main_out 0 100 >> assume.log
+./main_out 0 70 >> assume.log
+./main_out 260 1260 >> assume.log
+./main_out 10 45 >> assume.log
+./main_out -55 125 >> assume.log
+./main_out 20 80 >> assume.log
+./main_out 0 50 >> assume.log
+./main_out -0.2 2 >> assume.log
+./main_out 30 130 >> assume.log
+./main_out 1 200 >> assume.log

--- a/applications/newton/llvm-ir/performance_test/test_softfloat_assume.sh
+++ b/applications/newton/llvm-ir/performance_test/test_softfloat_assume.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -e
+
+[ -e assume.log ] && rm assume.log
+
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D ASSUME -D lowerBound=0 -D upperBound=100 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 0 100 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D ASSUME -D lowerBound=0 -D upperBound=70 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 0 70 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D ASSUME -D lowerBound=260 -D upperBound=1260 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 260 1260 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D ASSUME -D lowerBound=10 -D upperBound=45 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 10 45 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D ASSUME -D lowerBound=20 -D upperBound=80 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 20 80 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D ASSUME -D lowerBound=0 -D upperBound=50 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 0 50 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D ASSUME -D lowerBound=30 -D upperBound=130 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 30 130 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D ASSUME -D lowerBound=1 -D upperBound=200 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 1 200 >> assume.log
+
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D ASSUME -D lowerBound=0 -D upperBound=100 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 0 100 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D ASSUME -D lowerBound=0 -D upperBound=70 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 0 70 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D ASSUME -D lowerBound=260 -D upperBound=1260 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 260 1260 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D ASSUME -D lowerBound=10 -D upperBound=45 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 10 45 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D ASSUME -D lowerBound=20 -D upperBound=80 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 20 80 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D ASSUME -D lowerBound=0 -D upperBound=50 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 0 50 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D ASSUME -D lowerBound=30 -D upperBound=130 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 30 130 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D ASSUME -D lowerBound=1 -D upperBound=200 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 1 200 >> assume.log
+
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D ASSUME -D lowerBound=0 -D upperBound=100 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 0 100 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D ASSUME -D lowerBound=0 -D upperBound=70 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 0 70 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D ASSUME -D lowerBound=260 -D upperBound=1260 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 260 1260 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D ASSUME -D lowerBound=10 -D upperBound=45 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 10 45 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D ASSUME -D lowerBound=20 -D upperBound=80 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 20 80 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D ASSUME -D lowerBound=0 -D upperBound=50 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 0 50 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D ASSUME -D lowerBound=30 -D upperBound=130 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 30 130 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D ASSUME -D lowerBound=1 -D upperBound=200 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 1 200 >> assume.log
+
+echo "-----------------without assume-----------------" >> assume.log
+
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D lowerBound=0 -D upperBound=100 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 0 100 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D lowerBound=0 -D upperBound=70 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 0 70 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D lowerBound=260 -D upperBound=1260 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 260 1260 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D lowerBound=10 -D upperBound=45 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 10 45 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D lowerBound=20 -D upperBound=80 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 20 80 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D lowerBound=0 -D upperBound=50 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 0 50 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D lowerBound=30 -D upperBound=130 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 30 130 >> assume.log
+clang ../CHStone_test/dfadd/float64_add.cpp -D DEBUG -D lowerBound=1 -D upperBound=200 -O3 -o float64_add_assume -lm >& compile.log
+./float64_add_assume 1 200 >> assume.log
+
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D lowerBound=0 -D upperBound=100 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 0 100 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D lowerBound=0 -D upperBound=70 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 0 70 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D lowerBound=260 -D upperBound=1260 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 260 1260 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D lowerBound=10 -D upperBound=45 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 10 45 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D lowerBound=20 -D upperBound=80 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 20 80 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D lowerBound=0 -D upperBound=50 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 0 50 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D lowerBound=30 -D upperBound=130 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 30 130 >> assume.log
+clang ../CHStone_test/dfmul/float64_mul.cpp -D DEBUG -D lowerBound=1 -D upperBound=200 -O3 -o float64_mul_assume -lm >& compile.log
+./float64_mul_assume 1 200 >> assume.log
+
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D lowerBound=0 -D upperBound=100 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 0 100 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D lowerBound=0 -D upperBound=70 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 0 70 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D lowerBound=260 -D upperBound=1260 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 260 1260 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D lowerBound=10 -D upperBound=45 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 10 45 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D lowerBound=20 -D upperBound=80 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 20 80 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D lowerBound=0 -D upperBound=50 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 0 50 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D lowerBound=30 -D upperBound=130 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 30 130 >> assume.log
+clang ../CHStone_test/dfdiv/float64_div.cpp -D DEBUG -D lowerBound=1 -D upperBound=200 -O3 -o float64_div_assume -lm >& compile.log
+./float64_div_assume 1 200 >> assume.log

--- a/applications/newton/llvm-ir/test_madgwick.c
+++ b/applications/newton/llvm-ir/test_madgwick.c
@@ -17,9 +17,10 @@
 #include <time.h>
 
 #if defined(INT_DATA_TYPE)
+extern volatile int32_t	q0, q1, q2, q3;
 #include "c-files/MadgwickAHRSfix.h"
 #elif defined(FP_DATA_TYPE)
-
+extern volatile float	q0, q1, q2, q3;
 #if defined(SOFT_FLOAT_LIB)
 #include "c-files/MadgwickAHRS_softfloat.h"
 #else
@@ -32,7 +33,7 @@
 
 #define DATA_SIZE 1000
 
-#define ITERATION 5
+#define ITERATION 10
 
 /***************************************
  * Timer functions of the test framework
@@ -95,10 +96,28 @@ int main() {
 
     double time[DATA_SIZE];
 #if defined(INT_DATA_TYPE)
+    int32_t	q0[DATA_SIZE], q1[DATA_SIZE], q2[DATA_SIZE], q3[DATA_SIZE];
+    // quaternion of sensor frame relative to auxiliary frame
+    for (int i = 0; i < DATA_SIZE; i++) {
+        q0[i] = (0.64306622f*FRAC_BASE);
+        q1[i] = (0.02828862f*FRAC_BASE);
+        q2[i] = (-0.00567953f*FRAC_BASE);
+        q3[i] = (-0.76526684f*FRAC_BASE);
+    }
+
     int32_t mag_x[DATA_SIZE], mag_y[DATA_SIZE], mag_z[DATA_SIZE],
             gyr_x[DATA_SIZE], gyr_y[DATA_SIZE], gyr_z[DATA_SIZE],
             acc_x[DATA_SIZE], acc_y[DATA_SIZE], acc_z[DATA_SIZE];
 #elif defined(FP_DATA_TYPE)
+    float q0[DATA_SIZE], q1[DATA_SIZE], q2[DATA_SIZE], q3[DATA_SIZE];
+    // quaternion of sensor frame relative to auxiliary frame
+    for (int i = 0; i < DATA_SIZE; i++) {
+        q0[i] = 0.64306622f;
+        q1[i] = 0.02828862f;
+        q2[i] = -0.00567953f;
+        q3[i] = -0.76526684f;
+    }
+
     float mag_x[DATA_SIZE], mag_y[DATA_SIZE], mag_z[DATA_SIZE],
           gyr_x[DATA_SIZE], gyr_y[DATA_SIZE], gyr_z[DATA_SIZE],
           acc_x[DATA_SIZE], acc_y[DATA_SIZE], acc_z[DATA_SIZE];
@@ -124,65 +143,65 @@ int main() {
                     break;
                 case 1:
 #if defined(INT_DATA_TYPE)
-                    mag_x[row-2] = atoi(value);
+                    mag_x[row-2] = round(atof(value)*FRAC_BASE);
 #elif defined(FP_DATA_TYPE)
                     mag_x[row-2] = atof(value);
 #endif
                     break;
                 case 2:
 #if defined(INT_DATA_TYPE)
-                    mag_y[row-2] = atoi(value);
+                    mag_y[row-2] = round(atof(value)*FRAC_BASE);
 #elif defined(FP_DATA_TYPE)
                     mag_y[row-2] = atof(value);
 #endif
                     break;
                 case 3:
 #if defined(INT_DATA_TYPE)
-                    mag_z[row-2] = atoi(value);
+                    mag_z[row-2] = round(atof(value)*FRAC_BASE);
 #elif defined(FP_DATA_TYPE)
                     mag_z[row-2] = atof(value);
 #endif
                     break;
                 case 4:
 #if defined(INT_DATA_TYPE)
-                    gyr_x[row-2] = atoi(value);
+                    gyr_x[row-2] = round(atof(value)*FRAC_BASE)*61;
 #elif defined(FP_DATA_TYPE)
-                    gyr_x[row-2] = atof(value);
+                    gyr_x[row-2] = atof(value)*61;
 #endif
                     break;
                 case 5:
 #if defined(INT_DATA_TYPE)
-                    gyr_y[row-2] = atoi(value);
+                    gyr_y[row-2] = round(atof(value)*FRAC_BASE)*61;
 #elif defined(FP_DATA_TYPE)
-                    gyr_y[row-2] = atof(value);
+                    gyr_y[row-2] = atof(value)*61;
 #endif
                     break;
                 case 6:
 #if defined(INT_DATA_TYPE)
-                    gyr_z[row-2] = atoi(value);
+                    gyr_z[row-2] = round(atof(value)*FRAC_BASE)*61;
 #elif defined(FP_DATA_TYPE)
-                    gyr_z[row-2] = atof(value);
+                    gyr_z[row-2] = atof(value)*61;
 #endif
                     break;
                 case 7:
 #if defined(INT_DATA_TYPE)
-                    acc_x[row-2] = atoi(value);
+                    acc_x[row-2] = round(atof(value)*FRAC_BASE)*2;
 #elif defined(FP_DATA_TYPE)
-                    acc_x[row-2] = atof(value);
+                    acc_x[row-2] = atof(value)*2;
 #endif
                     break;
                 case 8:
 #if defined(INT_DATA_TYPE)
-                    acc_y[row-2] = atoi(value);
+                    acc_y[row-2] = round(atof(value)*FRAC_BASE)*2;
 #elif defined(FP_DATA_TYPE)
-                    acc_y[row-2] = atof(value);
+                    acc_y[row-2] = atof(value)*2;
 #endif
                     break;
                 case 9:
 #if defined(INT_DATA_TYPE)
-                    acc_z[row-2] = atoi(value);
+                    acc_z[row-2] = round(atof(value)*FRAC_BASE)*2;
 #elif defined(FP_DATA_TYPE)
-                    acc_z[row-2] = atof(value);
+                    acc_z[row-2] = atof(value)*2;
 #endif
                     break;
                 default:
@@ -196,14 +215,55 @@ int main() {
 
     fclose(fp);
 
+    u_int64_t time_slots[ITERATION];
+
     for (size_t idx = 0; idx < ITERATION; idx++) {
         timespec timer = tic();
         for (size_t ts = 0; ts < DATA_SIZE; ts++) {
             MadgwickAHRSupdate(gyr_x[ts], gyr_y[ts], gyr_z[ts],
                                acc_x[ts], acc_y[ts], acc_z[ts],
-                               mag_x[ts], mag_y[ts], mag_z[ts]);
+                               mag_x[ts], mag_y[ts], mag_z[ts],
+                               &q0[ts], &q1[ts], &q2[ts], &q3[ts]);
         }
-        toc(&timer, "computation delay");
+        time_slots[idx] = toc(&timer, "computation delay").tv_nsec;
     }
+
+    u_int64_t average_time = 0;
+    for (size_t idx = 0; idx < ITERATION; idx++) {
+        average_time += time_slots[idx];
+    }
+    average_time /= ITERATION;
+    printf("average time = %lu nm\n", average_time);
+
+#if defined(FP_DATA_TYPE)
+    FILE *fptr = fopen("fp_result.txt", "w");
+    for (size_t ts = 0; ts < DATA_SIZE; ts++) {
+//        printf("Original: q0[%d]=%f, q1[%d]=%f, q2[%d]=%f, q3[%d]=%f\n",
+//               ts, q0[ts], ts, q1[ts], ts, q2[ts], ts, q3[ts]);
+        fprintf(fptr, "Original: q0[%d]=%f, q1[%d]=%f, q2[%d]=%f, q3[%d]=%f\n",
+               ts, q0[ts], ts, q1[ts], ts, q2[ts], ts, q3[ts]);
+    }
+    fclose(fptr);
+#elif defined(INT_DATA_TYPE)
+    FILE *fptr = fopen("int_result.txt", "w");
+    for (size_t ts = 0; ts < DATA_SIZE; ts++) {
+//        printf("FIX: q0[%d]=%f, q1[%d]=%f, q2[%d]=%f, q3[%d]=%f\n",
+//               ts, (double)q0[ts]/FRAC_BASE,
+//               ts, (double)q1[ts]/FRAC_BASE,
+//               ts, (double)q2[ts]/FRAC_BASE,
+//               ts, (double)q3[ts]/FRAC_BASE);
+        fprintf(fptr, "FIX: q0[%d]=%f, q1[%d]=%f, q2[%d]=%f, q3[%d]=%f\n",
+               ts, (double)q0[ts]/FRAC_BASE,
+               ts, (double)q1[ts]/FRAC_BASE,
+               ts, (double)q2[ts]/FRAC_BASE,
+               ts, (double)q3[ts]/FRAC_BASE);
+    }
+    fclose(fptr);
+//    printf("FIX: q0 = %d.%04d, q1 = %d.%04d, q2 = %d.%04d, q3 = %d.%04d\n",
+//           DISPLAY_INT(q0), DISPLAY_FRAC(q0),
+//           DISPLAY_INT(q1), DISPLAY_FRAC(q1),
+//           DISPLAY_INT(q2), DISPLAY_FRAC(q2),
+//           DISPLAY_INT(q3), DISPLAY_FRAC(q3));
+#endif
     return 0;
 }

--- a/src/common/common-data-structures.h
+++ b/src/common/common-data-structures.h
@@ -720,6 +720,8 @@ typedef enum
 	kNewtonIrPassLLVMIRLivenessAnalysis				= (1 << 14),
 	kNewtonirPassLLVMIROptimizeByRange				= (1 << 15),
     kNewtonirPassLLVMIRAutoQuantization 			= (1 << 16),
+    kNewtonirPassLLVMIREnableOverload               = (1 << 17),
+    kNewtonirPassLLVMIREnableBuiltinAssume          = (1 << 18),
 	/*
 	 *	Code depends on this bringing up the rear.
 	 */

--- a/src/newton/Makefile
+++ b/src/newton/Makefile
@@ -101,6 +101,7 @@ SOURCES		=\
 		newton-irPass-LLVMIR-shrinkTypeByRange.cpp\
 		newton-irPass-LLVMIR-quantization.cpp\
 		newton-irPass-LLVMIR-memoryAlignment.cpp\
+		newton-irPass-LLVMIR-emitAssume.cpp\
 
 
 #
@@ -136,6 +137,7 @@ OBJS		=\
 		newton-irPass-LLVMIR-constantSubstitution.$(OBJECTEXTENSION)\
 		newton-irPass-LLVMIR-shrinkTypeByRange.$(OBJECTEXTENSION)\
 		newton-irPass-LLVMIR-quantization.$(OBJECTEXTENSION)\
+		newton-irPass-LLVMIR-emitAssume.$(OBJECTEXTENSION)\
 		newton-irPass-invariantSignalAnnotation.$(OBJECTEXTENSION)\
 		newton-irPass-piGroupsSignalAnnotation.$(OBJECTEXTENSION)\
 		newton-irPass-ipsaBackend.$(OBJECTEXTENSION)\
@@ -184,6 +186,7 @@ CGIOBJS		=\
 		newton-irPass-LLVMIR-constantSubstitution.$(OBJECTEXTENSION)\
 		newton-irPass-LLVMIR-shrinkTypeByRange.$(OBJECTEXTENSION)\
 		newton-irPass-LLVMIR-quantization.$(OBJECTEXTENSION)\
+		newton-irPass-LLVMIR-emitAssume.$(OBJECTEXTENSION)\
 		newton-irPass-invariantSignalAnnotation.$(OBJECTEXTENSION)\
 		newton-irPass-piGroupsSignalAnnotation.$(OBJECTEXTENSION)\
 		newton-irPass-estimatorSynthesisBackend/$(OBJECTEXTENSION)\
@@ -231,6 +234,7 @@ LIBNEWTONOBJS =\
 		newton-irPass-LLVMIR-constantSubstitution.$(OBJECTEXTENSION)\
 		newton-irPass-LLVMIR-shrinkTypeByRange.$(OBJECTEXTENSION)\
 		newton-irPass-LLVMIR-quantization.$(OBJECTEXTENSION)\
+		newton-irPass-LLVMIR-emitAssume.$(OBJECTEXTENSION)\
 		newton-irPass-invariantSignalAnnotation.$(OBJECTEXTENSION)\
 		newton-irPass-piGroupsSignalAnnotation.$(OBJECTEXTENSION)\
 		newton-irPass-ipsaBackend.$(OBJECTEXTENSION)\
@@ -367,6 +371,10 @@ newton-irPass-LLVMIR-quantization.$(OBJECTEXTENSION): newton-irPass-LLVMIR-quant
 	$(CXX) $(FLEXFLAGS) $(INCDIRS) $(CXXFLAGS) $(WFLAGS) $(OPTFLAGS) $<
 
 newton-irPass-LLVMIR-memoryAlignment.$(OBJECTEXTENSION): newton-irPass-LLVMIR-memoryAlignment.cpp
+	$(CXX) $(FLEXFLAGS) $(INCDIRS) $(CXXFLAGS) $(WFLAGS) $(OPTFLAGS) $(LINTFLAGS) $<
+	$(CXX) $(FLEXFLAGS) $(INCDIRS) $(CXXFLAGS) $(WFLAGS) $(OPTFLAGS) $<
+
+newton-irPass-LLVMIR-emitAssume.$(OBJECTEXTENSION): newton-irPass-LLVMIR-emitAssume.cpp
 	$(CXX) $(FLEXFLAGS) $(INCDIRS) $(CXXFLAGS) $(WFLAGS) $(OPTFLAGS) $(LINTFLAGS) $<
 	$(CXX) $(FLEXFLAGS) $(INCDIRS) $(CXXFLAGS) $(WFLAGS) $(OPTFLAGS) $<
 

--- a/src/newton/main.c
+++ b/src/newton/main.c
@@ -109,6 +109,8 @@ main(int argc, char *argv[])
 			{"targetParam",		required_argument,	0,	'T'},
 			{"llvm-ir",             required_argument,      0,      'I'},
 			{"llvm-ir-liveness-check",    no_argument,      0,      'L'},
+            {"llvm-ir-enable-overload",    no_argument,      0,      'o'},
+            {"llvm-ir-enable-builtin-assume",    no_argument,      0,      'A'},
             {"llvm-ir-auto-quantization",    no_argument,      0,      'Q'},
 			{"estimator-synthesis",	required_argument,	0,	420},
 			{"process",		required_argument,	0,	421},
@@ -423,6 +425,18 @@ main(int argc, char *argv[])
 				N->irPasses |= kNewtonirPassLLVMIROptimizeByRange;
 				break;
 			}
+
+            case 'o':
+            {
+                N->irPasses |= kNewtonirPassLLVMIREnableOverload;
+                break;
+            }
+
+            case 'A':
+            {
+                N->irPasses |= kNewtonirPassLLVMIREnableBuiltinAssume;
+                break;
+            }
 
             case 'Q':
             {

--- a/src/newton/newton-irPass-LLVMIR-emitAssume.cpp
+++ b/src/newton/newton-irPass-LLVMIR-emitAssume.cpp
@@ -1,0 +1,213 @@
+/*
+	Authored 2022. Pei Mu.
+	All rights reserved.
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions
+	are met:
+	*	Redistributions of source code must retain the above
+		copyright notice, this list of conditions and the following
+		disclaimer.
+	*	Redistributions in binary form must reproduce the above
+		copyright notice, this list of conditions and the following
+		disclaimer in the documentation and/or other materials
+		provided with the distribution.
+	*	Neither the name of the author nor the names of its
+		contributors may be used to endorse or promote products
+		derived from this software without specific prior written
+		permission.
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+	"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+	FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+	INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+	BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+	CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+	LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+	ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "newton-irPass-LLVMIR-emitAssume.h"
+
+using namespace llvm;
+
+extern "C" {
+/*
+ * emit a `llvm.assume` after each instruction if its range can be analyzed
+ * */
+void
+emitAssume(State * N, BoundInfo * boundInfo, llvm::Function & llvmIrFunction)
+{
+	for (BasicBlock & llvmIrBasicBlock : llvmIrFunction)
+	{
+		for (BasicBlock::iterator itBB = llvmIrBasicBlock.begin(); itBB != llvmIrBasicBlock.end();)
+		{
+			Instruction * llvmIrInstruction = &*itBB++;
+			switch (llvmIrInstruction->getOpcode())
+			{
+                /*
+                 * only emit after the instruction that is not supported by builtin_assume
+                 * */
+				case Instruction::Call:
+                    break;
+//				case Instruction::Add:
+//				case Instruction::FAdd:
+//				case Instruction::Sub:
+//				case Instruction::FSub:
+//				case Instruction::Mul:
+//				case Instruction::FMul:
+//				case Instruction::SDiv:
+//				case Instruction::FDiv:
+//				case Instruction::UDiv:
+//				case Instruction::URem:
+//				case Instruction::SRem:
+//				case Instruction::FRem:
+//				case Instruction::Shl:
+//				case Instruction::LShr:
+//				case Instruction::AShr:
+//				case Instruction::And:
+//				case Instruction::Or:
+//				case Instruction::Xor:
+//				case Instruction::FNeg:
+//				case Instruction::FPToUI:
+//				case Instruction::FPToSI:
+//				case Instruction::SIToFP:
+//				case Instruction::UIToFP:
+				case Instruction::ZExt:
+				case Instruction::SExt:
+				case Instruction::FPExt:
+				case Instruction::Trunc:
+				case Instruction::FPTrunc:
+				case Instruction::BitCast:
+				case Instruction::Load:
+				case Instruction::GetElementPtr:
+				case Instruction::PHI:
+                {
+                    auto vrIt = boundInfo->virtualRegisterRange.find(llvmIrInstruction);
+                    if (vrIt == boundInfo->virtualRegisterRange.end()) {
+                        break;
+                    }
+                    IRBuilder<> Builder(&llvmIrBasicBlock);
+                    /*
+                     * Phi node should be at the top of block,
+                     * so move back the insert point until it's not a Phi node.
+                     * */
+                    auto insertPoint = llvmIrInstruction->getNextNode();
+                    while (isa<PHINode>(insertPoint))
+                    {
+                        insertPoint = insertPoint->getNextNode();
+                    }
+                    Builder.SetInsertPoint(insertPoint);
+
+                    Function* assumeIntrinsic = Intrinsic::getDeclaration(
+                            llvmIrFunction.getParent(), Intrinsic::assume
+                            );
+                    /*
+                     * 1. get lower/upper bound from map
+                     * 2. check lower bound <= upper bound
+                     * 3. icmp for INT comparison; fcmp for FP comparison
+                     * */
+                    auto lowerBound = vrIt->second.first;
+                    auto upperBound = vrIt->second.second;
+                    if (lowerBound > upperBound) {
+                        /*if this happens, there might be a bug*/
+                        break;
+                    }
+
+                    /*
+                     * The excepted code is:
+                     * block_a:
+                     * %cmp1 = cmpInst
+                     * br i1 %cmp1, label %block_b, label %block_c
+                     *
+                     * block_b:
+                     * %cmp2 = cmpInst
+                     * br label %block_c
+                     *
+                     * block_c:
+                     * %v = phi i1 [false, %block_a], [%cmp2, %block_b]
+                     * call void @llvm.assume(i1 %v)
+                     * */
+                    Value *assumeLowerCond, *assumeUpperCond;
+                    Type *instType = llvmIrInstruction->getType();
+                    /*
+                     * skip pointer type
+                     * */
+                    if (instType->isPointerTy()) {
+                        break;
+                    }
+
+                    if (std::isnan(lowerBound) || std::isnan(upperBound)) {
+                        break;
+                    }
+
+                    if (std::isinf(lowerBound) || std::isinf(upperBound)) {
+                        break;
+                    }
+
+                    if (instType->isFloatTy() || instType->isDoubleTy()) {
+                        assumeLowerCond = Builder.CreateFCmpOGE(llvmIrInstruction,
+                                                                ConstantFP::get(instType, lowerBound));
+                        assumeUpperCond = Builder.CreateFCmpOLE(llvmIrInstruction,
+                                                                ConstantFP::get(instType, upperBound));
+                    } else {
+                        if (lowerBound < 0) {
+                            assumeLowerCond = Builder.CreateICmpSGE(llvmIrInstruction,
+                                                                    ConstantInt::get(instType, (int)lowerBound, true));
+                            assumeUpperCond = Builder.CreateICmpSLE(llvmIrInstruction,
+                                                                    ConstantInt::get(instType, (int)upperBound, true));
+                        } else {
+                            assumeLowerCond = Builder.CreateICmpUGE(llvmIrInstruction,
+                                                                    ConstantInt::get(instType, (int)lowerBound, false));
+                            assumeUpperCond = Builder.CreateICmpULE(llvmIrInstruction,
+                                                                    ConstantInt::get(instType, (int)upperBound, false));
+                        }
+                    }
+                    auto assumeCond = Builder.CreateLogicalAnd(assumeLowerCond, assumeUpperCond);
+                    Value* assumeInst = Builder.CreateCall(assumeIntrinsic, assumeCond);
+                }
+                    break;
+				case Instruction::Store:
+				case Instruction::ICmp:
+				case Instruction::FCmp:
+				case Instruction::Ret:
+				case Instruction::Switch:
+				case Instruction::Br:
+				case Instruction::Select:
+				case Instruction::IndirectBr:
+				case Instruction::Invoke:
+				case Instruction::Resume:
+				case Instruction::Unreachable:
+				case Instruction::CleanupRet:
+				case Instruction::CatchRet:
+				case Instruction::CatchSwitch:
+				case Instruction::CallBr:
+				case Instruction::Fence:
+				case Instruction::AtomicCmpXchg:
+				case Instruction::AtomicRMW:
+				case Instruction::PtrToInt:
+				case Instruction::IntToPtr:
+				case Instruction::AddrSpaceCast:
+				case Instruction::CleanupPad:
+				case Instruction::CatchPad:
+				case Instruction::UserOp1:
+				case Instruction::UserOp2:
+				case Instruction::VAArg:
+				case Instruction::ExtractElement:
+				case Instruction::InsertElement:
+				case Instruction::ShuffleVector:
+				case Instruction::ExtractValue:
+				case Instruction::InsertValue:
+				case Instruction::LandingPad:
+				case Instruction::Freeze:
+					break;
+				default:
+					break;
+			}
+		}
+	}
+	return;
+}
+}

--- a/src/newton/newton-irPass-LLVMIR-emitAssume.h
+++ b/src/newton/newton-irPass-LLVMIR-emitAssume.h
@@ -1,0 +1,44 @@
+/*
+	Authored 2022. Pei Mu.
+	All rights reserved.
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions
+	are met:
+	*	Redistributions of source code must retain the above
+		copyright notice, this list of conditions and the following
+		disclaimer.
+	*	Redistributions in binary form must reproduce the above
+		copyright notice, this list of conditions and the following
+		disclaimer in the documentation and/or other materials
+		provided with the distribution.
+	*	Neither the name of the author nor the names of its
+		contributors may be used to endorse or promote products
+		derived from this software without specific prior written
+		permission.
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+	"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+	FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+	COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+	INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+	BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+	CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+	LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+	ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "newton-irPass-LLVMIR-rangeAnalysis.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+void
+emitAssume(State * N, BoundInfo * boundInfo, llvm::Function & llvmIrFunction);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */

--- a/src/newton/newton-irPass-LLVMIR-optimizeByRange.h
+++ b/src/newton/newton-irPass-LLVMIR-optimizeByRange.h
@@ -44,7 +44,7 @@ extern "C"
 #endif /* __cplusplus */
 
 void
-irPassLLVMIROptimizeByRange(State * N);
+irPassLLVMIROptimizeByRange(State * N, bool enableQuantization, bool enableOverload, bool enableBuiltinAssume);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/newton/newton-irPass-LLVMIR-quantization.cpp
+++ b/src/newton/newton-irPass-LLVMIR-quantization.cpp
@@ -33,25 +33,408 @@
 
 using namespace llvm;
 
+#define FRAC_Q			16
+#define FRAC_BASE		(1<<FRAC_Q)
+#define BIT_WIDTH        32
+
 extern "C"
 {
+void setQuantizedType(Value * inValue, Type * quantizedType) {
+    auto valueType = inValue->getType();
+    unsigned pointerAddr;
+    bool	 isPointer = false;
+    if (valueType != nullptr)
+    {
+        if (valueType->isPointerTy()) {
+            isPointer = true;
+            pointerAddr = valueType->getPointerAddressSpace();
+            valueType = valueType->getPointerElementType();
+        }
+        if (valueType->isDoubleTy() || valueType->isFloatTy() || valueType->isArrayTy())
+        {
+            if (isPointer) {
+                inValue->mutateType(quantizedType->getPointerTo(pointerAddr));
+            } else {
+                inValue->mutateType(quantizedType);
+            }
+        }
+    }
+}
+
+void quantizeConstant(Instruction * inInstruction, Type * quantizedType) {
+    for (size_t idx = 0; idx < inInstruction->getNumOperands(); idx++) {
+        Value * inValue = inInstruction->getOperand(idx);
+
+        if (!isa<llvm::ConstantFP>(inValue)) {
+            continue;
+        }
+
+        ConstantFP * constFp = llvm::dyn_cast<llvm::ConstantFP>(inValue);
+        Value * newValue = nullptr;
+        if (inValue->getType()->isFloatTy())
+        {
+            float constValue = constFp->getValueAPF().convertToFloat();
+            constValue *= FRAC_BASE;
+            newValue	 = ConstantInt::get(quantizedType, round(constValue), true);
+        }
+        else if (inValue->getType()->isDoubleTy())
+        {
+            double constValue = constFp->getValueAPF().convertToDouble();
+            constValue *= FRAC_BASE;
+            newValue	 = ConstantInt::get(quantizedType, round(constValue), true);
+        }
+        else
+        {
+            assert(false && "unknown floating type");
+        }
+
+        inInstruction->replaceUsesOfWith(inValue, newValue);
+    }
+}
+
+void simplifyConstant(Instruction * inInstruction, Type * quantizedType) {
+    auto checkDecimal = [](float decimalNum) {
+        int digits = 0;
+        /*
+         * Since the max value of `int16` is 32767,
+         * we maximum multiply with 1,000 to make sure it won't exceed max_int16
+         * */
+        while (fabs(round(decimalNum) - decimalNum) > 0.001 && digits < 4) {
+            decimalNum *= 10;
+            digits++;
+        }
+        return decimalNum;
+    };
+
+    auto compensateFP = [inInstruction, quantizedType](float quantizedNum, float decimalNum) {
+        /*
+         * 3333.3 / 3.3333 = 1000
+         * ===>
+         * Example 1:
+         * a * 3.3333 ~= a * (3333 / 1000) ~= (int)a * 3333 / 1000
+         *
+         * Example 2:
+         * a / 3.3333 ~= a / (3333 / 1000) ~= (int)a * 1000 / 3333
+         *
+         * Example 3:
+         * 3.3333 / a ~= (3333 / 1000) / a ~= 3333 / (int)a / 1000
+         * */
+        float compensateNum = quantizedNum / decimalNum;
+
+        Value *constOperand, *nonConstOperand;
+        unsigned constIdx, nonConstIdx;
+        if (isa<llvm::Constant>(inInstruction->getOperand(0))) {
+            constIdx = 0;
+            nonConstIdx = 1;
+            constOperand = inInstruction->getOperand(0);
+            nonConstOperand = inInstruction->getOperand(1);
+        } else {
+            constIdx = 1;
+            nonConstIdx = 0;
+            constOperand = inInstruction->getOperand(1);
+            nonConstOperand = inInstruction->getOperand(0);
+        }
+
+        auto quantizeNumValue = ConstantInt::get(quantizedType, round(quantizedNum), true);
+
+        if (compensateNum == 1) {
+            inInstruction->setOperand(constIdx, quantizeNumValue);
+        } else {
+            auto compensateNumValue = ConstantInt::get(quantizedType, round(compensateNum), true);
+
+            IRBuilder<> Builder(inInstruction);
+            Instruction * insertPoint = inInstruction->getNextNode();
+            Builder.SetInsertPoint(insertPoint);
+            Value * newFisrtInst = nullptr;
+            Value * newSecondInst = nullptr;
+            auto instOpCode = inInstruction->getOpcode();
+            if (instOpCode == Instruction::FMul) {
+                newFisrtInst = Builder.CreateMul(nonConstOperand, quantizeNumValue);
+                newSecondInst = Builder.CreateSDiv(newFisrtInst, compensateNumValue);
+            } else if (instOpCode == Instruction::FDiv && isa<llvm::Constant>(inInstruction->getOperand(1))) {
+                newFisrtInst = Builder.CreateMul(nonConstOperand, compensateNumValue);
+                newSecondInst = Builder.CreateSDiv(newFisrtInst, quantizeNumValue);
+            } else if (instOpCode == Instruction::FDiv && isa<llvm::Constant>(inInstruction->getOperand(0))) {
+                newFisrtInst = Builder.CreateSDiv(quantizeNumValue, nonConstOperand);
+                newSecondInst = Builder.CreateSDiv(newFisrtInst, compensateNumValue);
+            }
+
+            inInstruction->replaceAllUsesWith(newSecondInst);
+            inInstruction->removeFromParent();
+        }
+    };
+
+    for (size_t idx = 0; idx < inInstruction->getNumOperands(); idx++) {
+        Value * inValue = inInstruction->getOperand(idx);
+
+        if (!isa<llvm::ConstantFP>(inValue)) {
+            continue;
+        }
+
+        ConstantFP * constFp = llvm::dyn_cast<llvm::ConstantFP>(inValue);
+        Value * newValue = nullptr;
+        if (inValue->getType()->isFloatTy())
+        {
+            float constValue = constFp->getValueAPF().convertToFloat();
+            compensateFP(checkDecimal(constValue), constValue);
+        }
+        else if (inValue->getType()->isDoubleTy())
+        {
+            double constValue = constFp->getValueAPF().convertToDouble();
+            compensateFP(checkDecimal(constValue), constValue);
+        }
+        else
+        {
+            assert(false && "unknown floating type");
+        }
+    }
+}
+
+llvm::Function * createFixMul(llvm::Function * inFunction, Type * quantizedType, std::vector<llvm::Function*>& functionsToInsert) {
+    /*
+     * check if this function is exist
+     * */
+    std::string fixmulFuncName = "fixmul";
+    auto irModule = inFunction->getParent();
+    for (auto & function : *irModule) {
+        if (function.getName() == fixmulFuncName) {
+            return &function;
+        }
+    }
+
+    llvm::FunctionType * funcType = llvm::FunctionType::get(quantizedType, {quantizedType, quantizedType}, false);
+    llvm::Function * func = llvm::Function::Create(funcType, llvm::Function::PrivateLinkage, fixmulFuncName, irModule);
+
+    llvm::BasicBlock* entryBB = llvm::BasicBlock::Create(inFunction->getContext(), "entry", func);
+    llvm::IRBuilder<> builder(entryBB);
+    builder.SetInsertPoint(entryBB);
+
+    /*
+     * ((int64_t)x*y)>>FRAC_Q
+     *
+     * ===========>
+     *
+     * define private i32 @mulfix(i32 %0, i32 %1) {
+     * %3 = sext i32 %0 to i64
+     * %4 = sext i32 %1 to i64
+     * %5 = mul nsw i64 %3, %4
+     * %6 = ashr i64 %5, 8
+     * %7 = trunc i64 %6 to i32
+     * ret i32 %7
+     * }
+     * */
+    Type* higherQuantizedType;
+    switch (BIT_WIDTH) {
+        case 8:
+            higherQuantizedType = Type::getInt16Ty(inFunction->getContext());
+            break;
+        case 16:
+            higherQuantizedType = Type::getInt32Ty(inFunction->getContext());
+            break;
+        default:
+            higherQuantizedType = Type::getInt64Ty(inFunction->getContext());
+            break;
+    }
+
+    llvm::Function::arg_iterator arg1 = &*(func->arg_begin());
+    llvm::Value* sext1 = builder.CreateSExt(arg1, higherQuantizedType);
+    llvm::Function::arg_iterator arg2 = &*(++arg1);
+    llvm::Value* sext2 = builder.CreateSExt(arg2, higherQuantizedType);
+    llvm::Value* mulInst = builder.CreateMul(sext1, sext2);
+    llvm::Value* ashrInst = builder.CreateAShr(mulInst, ConstantInt::get(higherQuantizedType, FRAC_Q));
+    llvm::Value* truncInst = builder.CreateTrunc(ashrInst, quantizedType);
+    builder.CreateRet(truncInst);
+
+    functionsToInsert.emplace_back(func);
+
+    return func;
+}
+
+void substituteHardcodeFunc(Instruction * inInstruction, Type * quantizedType, llvm::Function * func) {
+    IRBuilder<> Builder(inInstruction);
+    Instruction * insertPoint = inInstruction->getNextNode();
+    Builder.SetInsertPoint(insertPoint);
+//    Value * newInst = nullptr;
+
+    llvm::CallInst* callInst = Builder.CreateCall(func, {inInstruction->getOperand(0), inInstruction->getOperand(1)});
+//    InlineFunctionInfo inlineFuncInfo;
+//    llvm::InlineFunction(*callInst, inlineFuncInfo);
+
+    inInstruction->replaceAllUsesWith(callInst);
+    inInstruction->removeFromParent();
+}
+
+CmpInst::Predicate quantizePredict(CmpInst::Predicate predict) {
+    switch (predict) {
+        case FCmpInst::FCMP_OEQ:
+        case FCmpInst::FCMP_UEQ:
+            return ICmpInst::ICMP_EQ;
+        case FCmpInst::FCMP_OGT:
+        case FCmpInst::FCMP_UGT:
+            return ICmpInst::ICMP_SGT;
+        case FCmpInst::FCMP_OGE:
+        case FCmpInst::FCMP_UGE:
+            return ICmpInst::ICMP_SGE;
+        case FCmpInst::FCMP_OLT:
+        case FCmpInst::FCMP_ULT:
+            return ICmpInst::ICMP_SLT;
+        case FCmpInst::FCMP_OLE:
+        case FCmpInst::FCMP_ULE:
+            return ICmpInst::ICMP_SLE;
+        case FCmpInst::FCMP_ONE:
+        case FCmpInst::FCMP_UNE:
+            return ICmpInst::ICMP_NE;
+    }
+}
+
+void quantizeSimpleFPInstruction(Instruction * inInstruction, Type * quantizedType) {
+    IRBuilder<> Builder(inInstruction);
+    Instruction * insertPoint = inInstruction->getNextNode();
+    Builder.SetInsertPoint(insertPoint);
+    Value * newInst = nullptr;
+    switch (inInstruction->getOpcode())
+    {
+        case Instruction::FAdd:
+        {
+            newInst = Builder.CreateAdd(inInstruction->getOperand(0), inInstruction->getOperand(1));
+            break;
+        }
+        case Instruction::FSub:
+        {
+            newInst = Builder.CreateSub(inInstruction->getOperand(0), inInstruction->getOperand(1));
+            break;
+        }
+        case Instruction::FRem:
+        {
+            newInst = Builder.CreateSRem(inInstruction->getOperand(0), inInstruction->getOperand(1));
+            break;
+        }
+        case Instruction::FCmp:
+        {
+            FCmpInst *fcmp_inst = dyn_cast<FCmpInst>(inInstruction);
+            newInst = Builder.CreateICmp(quantizePredict(fcmp_inst->getPredicate()),
+                                         fcmp_inst->getOperand(0), fcmp_inst->getOperand(1));
+            break;
+        }
+        /*
+         * Change fneg(a) to `0-a`.
+         * */
+        case Instruction::FNeg:
+        {
+            auto constZero = ConstantInt::get(quantizedType, 0, true);
+            newInst = Builder.CreateSub(constZero, inInstruction->getOperand(0));
+            break;
+        }
+        default:
+            break;
+    }
+    inInstruction->replaceAllUsesWith(newInst);
+    inInstruction->removeFromParent();
+}
+
+void adaptTypeCast(llvm::Function & llvmIrFunction, Type * quantizedType) {
+    for (BasicBlock & llvmIrBasicBlock : llvmIrFunction) {
+        for (BasicBlock::iterator itBB = llvmIrBasicBlock.begin(); itBB != llvmIrBasicBlock.end();) {
+            Instruction *llvmIrInstruction = &*itBB++;
+            switch (llvmIrInstruction->getOpcode()) {
+                case Instruction::FPToUI:
+                case Instruction::FPToSI:
+                case Instruction::SIToFP:
+                case Instruction::UIToFP:
+                {
+                    auto sourceOp = llvmIrInstruction->getOperand(0);
+                    if (sourceOp->getType() == llvmIrInstruction->getType())
+                    {
+                        llvmIrInstruction->replaceAllUsesWith(sourceOp);
+                        llvmIrInstruction->removeFromParent();
+                    }
+                }
+                    break;
+//				case Instruction::ZExt:
+//				case Instruction::SExt:
+//				case Instruction::Trunc:
+                    /*
+                     * since the src type changed, adapt the new instruction
+                     * */
+                case Instruction::FPExt:
+                case Instruction::FPTrunc:
+                {
+                    IRBuilder<> Builder(llvmIrInstruction);
+                    Instruction * insertPoint = llvmIrInstruction->getNextNode();
+                    Builder.SetInsertPoint(insertPoint);
+                    Value * newInst = nullptr;
+                    if (llvmIrInstruction->getOperand(0)->getType()->isIntegerTy()) {
+                        newInst = Builder.CreateSIToFP(
+                                llvmIrInstruction->getOperand(0), llvmIrInstruction->getType());
+                    } else {
+                        newInst = Builder.CreateFPCast(
+                                llvmIrInstruction->getOperand(0), llvmIrInstruction->getType());
+                    }
+                    llvmIrInstruction->replaceAllUsesWith(newInst);
+                    llvmIrInstruction->removeFromParent();
+                    break;
+                }
+                case Instruction::BitCast:
+                {
+                    IRBuilder<> Builder(llvmIrInstruction);
+                    Instruction * insertPoint = llvmIrInstruction->getNextNode();
+                    Builder.SetInsertPoint(insertPoint);
+                    Value * newInst = Builder.CreateBitCast(
+                            llvmIrInstruction->getOperand(0), llvmIrInstruction->getType());
+                    llvmIrInstruction->replaceAllUsesWith(newInst);
+                    llvmIrInstruction->removeFromParent();
+                    break;
+                }
+            }
+        }
+    }
+}
+
 void
-irPassLLVMIRAutoQuantization(State * N, BoundInfo * boundInfo, llvm::Function & llvmIrFunction)
+irPassLLVMIRAutoQuantization(State * N, llvm::Function & llvmIrFunction, std::vector<llvm::Function*>& functionsToInsert)
 {
     flexprint(N->Fe, N->Fm, N->Fpinfo, "\tauto quantization.\n");
-	/*
-	 * Some special instructions that need to pay attention:
-	 * %i = alloca type, the type of this instruction is "type*"
-	 * %i = call retType @func_name (type %p1, ...)
-	 * call void @llvm.dbg.declare/value (metadata type %p, ...)
-	 * %i = load type, type* %op, the type of this instruction is "type"
-	 * %i = gep type, type1* %op1, type2 %op2, (type3 %op3)
-	 * %i = castInst type1 %op1 to type2
-	 * store type %op1, type* %op2
-	 * %.i = phi type [%op1, %bb1], [%op2, %bb2], ...
-	 * %i = binary type %op1, %op2
-	 * %i = unary type %op
-	 * */
+
+    Type* quantizedType;
+    switch (BIT_WIDTH) {
+        case 8:
+            quantizedType = Type::getInt8Ty(llvmIrFunction.getContext());
+            break;
+        case 16:
+            quantizedType = Type::getInt16Ty(llvmIrFunction.getContext());
+            break;
+        case 32:
+            quantizedType = Type::getInt32Ty(llvmIrFunction.getContext());
+            break;
+        case 64:
+            quantizedType = Type::getInt64Ty(llvmIrFunction.getContext());
+            break;
+        default:
+            flexprint(N->Fe, N->Fm, N->Fperr, "\tunknown int type.\n");
+            return;
+    }
+
+    /*
+     * change the type of this function if it's fp
+     * */
+    if (llvmIrFunction.getReturnType()->isFloatTy() || llvmIrFunction.getReturnType()->isDoubleTy()) {
+        llvmIrFunction.mutateType(quantizedType);
+    }
+
+    /*
+     * generate hardcode function - fixmul and fixdiv
+     * */
+    llvm::Function * fixmul = createFixMul(&llvmIrFunction, quantizedType, functionsToInsert);
+
+    /*
+     * quantize the arguments type
+     * */
+    for (int idx = 0; idx < llvmIrFunction.arg_size(); idx++)
+    {
+        auto	 paramOp	 = llvmIrFunction.getArg(idx);
+        setQuantizedType(paramOp, quantizedType);
+    }
+
 	for (BasicBlock & llvmIrBasicBlock : llvmIrFunction)
 	{
 		for (BasicBlock::iterator itBB = llvmIrBasicBlock.begin(); itBB != llvmIrBasicBlock.end();)
@@ -59,42 +442,211 @@ irPassLLVMIRAutoQuantization(State * N, BoundInfo * boundInfo, llvm::Function & 
 			Instruction * llvmIrInstruction = &*itBB++;
 			switch (llvmIrInstruction->getOpcode())
 			{
+                case Instruction::Alloca:
+                    if (auto llvmIrAllocaInstruction = dyn_cast<AllocaInst>(llvmIrInstruction))
+                    {
+                        auto allocaType = llvmIrAllocaInstruction->getAllocatedType();
+                        auto newType = quantizedType;
+                        if (allocaType->getTypeID() == Type::ArrayTyID) {
+                            newType = ArrayType::get(quantizedType,
+                                                     allocaType->getArrayNumElements());
+                            allocaType = allocaType->getArrayElementType();
+                        }
+                        if (allocaType->isDoubleTy() || allocaType->isFloatTy()) {
+                            llvmIrAllocaInstruction->setAllocatedType(newType);
+                        }
+                        setQuantizedType(llvmIrAllocaInstruction, newType);
+                    }
+                    break;
 				case Instruction::Call:
-				case Instruction::Add:
-				case Instruction::FAdd:
-				case Instruction::Sub:
-				case Instruction::FSub:
-				case Instruction::Mul:
-				case Instruction::FMul:
-				case Instruction::SDiv:
-				case Instruction::FDiv:
-				case Instruction::UDiv:
-				case Instruction::URem:
-				case Instruction::SRem:
-				case Instruction::FRem:
-				case Instruction::Shl:
-				case Instruction::LShr:
-				case Instruction::AShr:
-				case Instruction::And:
-				case Instruction::Or:
-				case Instruction::Xor:
-				case Instruction::FNeg:
+                    if (auto llvmIrCallInstruction = dyn_cast<CallInst>(llvmIrInstruction))
+                    {
+                        Function * calledFunction = llvmIrCallInstruction->getCalledFunction();
+                        if (calledFunction == nullptr || !calledFunction->hasName() || calledFunction->getName().empty())
+                            break;
+                        if (!calledFunction->getName().startswith("llvm.dbg.value") &&
+                            !calledFunction->getName().startswith("llvm.dbg.declare") &&
+                            !calledFunction->getName().startswith("llvm.dbg.label"))
+                        {
+                            if (calledFunction->isDeclaration())
+                            {
+                                IRBuilder<> Builder(llvmIrCallInstruction);
+                                Instruction * insertPoint = llvmIrCallInstruction->getNextNode();
+                                Builder.SetInsertPoint(insertPoint);
+                                Value * newInst = nullptr;
+                                if (calledFunction->getName().str() == "sqrt") {
+                                    /*
+                                     * if the arg's type is int, convert to fp,
+                                     * after the call node, convert to int and shl FRAC_Q/2
+                                     *
+                                     * int32_t res = (int32_t)sqrt(x)<<(FRAC_Q/2);
+                                     * if (FRAC_Q%2)
+                                     *   return res*1.414213562;
+                                     * else
+                                     *   return res;
+                                     *
+                                     * %25 = sitofp i32 %0 to double
+                                     * %26 = call double @sqrt(double %25) #3
+                                     * %27 = fptosi double %26 to i32
+                                     * %28 = shl i32 %27, 4
+                                     * */
+                                    auto operand = llvmIrCallInstruction->getOperand(0);
+                                    if (operand->getType()->isIntegerTy()) {
+                                        Value * newOperand = Builder.CreateSIToFP(
+                                                operand, llvmIrCallInstruction->getType());
+                                        llvmIrCallInstruction->setOperand(0, newOperand);
+                                    }
+                                    auto cloneInst = llvmIrCallInstruction->clone();
+                                    Value * fptosiInst = Builder.CreateFPToSI(
+                                            cloneInst, quantizedType);
+                                    Value * shlInst = Builder.CreateShl(fptosiInst, FRAC_Q/2);
+                                    Value * resInst = nullptr;
+                                    /*
+                                     * if (FRAC_Q%2) then multiply with 1.414213562;
+                                     * */
+                                    if (FRAC_Q%2) {
+                                        Value * lhsCompensateInst = Builder.CreateSIToFP(
+                                                shlInst, llvmIrCallInstruction->getType());
+                                        auto compensateNum = ConstantFP::get(llvmIrCallInstruction->getType(),
+                                                                            1.414213562);
+                                        Value * mulInst = Builder.CreateFMul(lhsCompensateInst, compensateNum);
+                                        resInst = Builder.CreateFPToSI(mulInst, quantizedType);
+                                    } else {
+                                        resInst = shlInst;
+                                    }
+                                    llvmIrCallInstruction->replaceAllUsesWith(resInst);
+                                    ReplaceInstWithInst(llvmIrCallInstruction, cloneInst);
+                                }
+                                else {
+                                    /*
+                                     * for other lib functions, de-quantize the arguments and quantize the return value
+                                     * */
+                                }
+                            } else {
+                                /*
+                                 * for user-defined function, quantize the arguments
+                                 * */
+                                for (size_t idx = 0; idx < llvmIrCallInstruction->getNumOperands() - 1; idx++)
+                                {
+                                    setQuantizedType(llvmIrCallInstruction->getOperand(idx), quantizedType);
+                                }
+                                quantizeConstant(llvmIrCallInstruction, quantizedType);
+                                /*
+                                 * then quantize the return type
+                                 * */
+                                setQuantizedType(llvmIrCallInstruction, quantizedType);
+                            }
+                        }
+                    }
+                    break;
+                case Instruction::GetElementPtr:
+                    if (auto gepInst = dyn_cast<GetElementPtrInst>(llvmIrInstruction))
+                    {
+                        auto gepType = gepInst->getType();
+                        auto sourceType = quantizedType;
+//                        bool isPointer = false;
+//                        unsigned pointerAddr = 0;
+//                        if (gepType->isPointerTy()) {
+//                            isPointer = true;
+//                            pointerAddr = gepType->getPointerAddressSpace();
+//                            valueType = gepType->getPointerElementType();
+//                        }
+                        if (gepInst->getSourceElementType()->getTypeID() == Type::ArrayTyID) {
+                            sourceType = ArrayType::get(quantizedType,
+                                                     gepInst->getSourceElementType()->getArrayNumElements());
+                        }
+//                        if (isPointer) {
+//                            inValue->mutateType(quantizedType->getPointerTo(pointerAddr));
+//                        }
+//                        if (gepType->isDoubleTy() || gepType->isFloatTy()) {
+                            gepInst->setSourceElementType(sourceType);
+                            gepInst->setResultElementType(quantizedType);
+//                        }
+                    }
+                case Instruction::Load:
+                case Instruction::PHI:
+                {
+                    setQuantizedType(llvmIrInstruction, quantizedType);
+                }
+                    break;
+
+                case Instruction::Store:
+                {
+                    /*
+                     * If either of the operands is constant, change it to a int value
+                     * */
+                    setQuantizedType(llvmIrInstruction->getOperand(0), quantizedType);
+                    quantizeConstant(llvmIrInstruction, quantizedType);
+                }
+                break;
+
+                /*
+                 * For fmul/fdiv,
+                 *
+                 * if either one of the operands is a constant value, simplify it by multiplying with 10^n,
+                 * then replace the instruction to mul/div;
+                 *
+                 * else substitute this instruction to a pre-implemented function: mulfix/divfix.
+                 * */
+                case Instruction::FMul:
+                case Instruction::FDiv:
+                {
+                    if (isa<llvm::Constant>(llvmIrInstruction->getOperand(0)) ||
+                            isa<llvm::Constant>(llvmIrInstruction->getOperand(1))) {
+                        simplifyConstant(llvmIrInstruction, quantizedType);
+                    }
+                    else {
+                        substituteHardcodeFunc(llvmIrInstruction, quantizedType, fixmul);
+                    }
+                    break;
+                }
+
+                /*
+                 * If either one of the operands is a constant value, quantize it,
+                 * then replace the instruction to the int version.
+                 * */
+                case Instruction::FCmp:
+                case Instruction::FAdd:
+                case Instruction::FSub:
+                case Instruction::FRem:
+                {
+                    quantizeConstant(llvmIrInstruction, quantizedType);
+                }
+                case Instruction::FNeg:
+                {
+                    quantizeSimpleFPInstruction(llvmIrInstruction, quantizedType);
+                    break;
+                }
+
+//                case Instruction::Add:
+//                case Instruction::Sub:
+//                case Instruction::Mul:
+//                case Instruction::UDiv:
+//				case Instruction::SDiv:
+//                case Instruction::URem:
+//                case Instruction::SRem:
+//
+//				case Instruction::Shl:
+//				case Instruction::LShr:
+//				case Instruction::AShr:
+//				case Instruction::And:
+//				case Instruction::Or:
+//				case Instruction::Xor:
+//
+//                case Instruction::ICmp:
+
 				case Instruction::FPToUI:
 				case Instruction::FPToSI:
 				case Instruction::SIToFP:
 				case Instruction::UIToFP:
 				case Instruction::ZExt:
 				case Instruction::SExt:
-				case Instruction::FPExt:
 				case Instruction::Trunc:
+                case Instruction::FPExt:
 				case Instruction::FPTrunc:
 				case Instruction::BitCast:
-				case Instruction::Load:
-				case Instruction::GetElementPtr:
-				case Instruction::PHI:
-				case Instruction::Store:
-				case Instruction::ICmp:
-				case Instruction::FCmp:
+                    break;
+
 				case Instruction::Ret:
 				case Instruction::Switch:
 				case Instruction::Br:
@@ -131,6 +683,9 @@ irPassLLVMIRAutoQuantization(State * N, BoundInfo * boundInfo, llvm::Function & 
 			}
 		}
 	}
+
+    adaptTypeCast(llvmIrFunction, quantizedType);
+
 	return;
 }
 }

--- a/src/newton/newton-irPass-LLVMIR-quantization.h
+++ b/src/newton/newton-irPass-LLVMIR-quantization.h
@@ -37,7 +37,7 @@ extern "C"
 #endif /* __cplusplus */
 
 void
-irPassLLVMIRAutoQuantization(State * N, BoundInfo * boundInfo, llvm::Function & llvmIrFunction);
+irPassLLVMIRAutoQuantization(State * N, llvm::Function & llvmIrFunction, std::vector<llvm::Function*>& functionsToInsert);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/newton/newton-irPass-LLVMIR-rangeAnalysis.h
+++ b/src/newton/newton-irPass-LLVMIR-rangeAnalysis.h
@@ -67,6 +67,7 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/InstIterator.h"
+#include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Value.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Support/SourceMgr.h"

--- a/src/newton/newton.c
+++ b/src/newton/newton.c
@@ -204,7 +204,10 @@ processNewtonFile(State *  N, char *  filename)
 	}
 	if (N->irPasses & kNewtonirPassLLVMIROptimizeByRange)
 	{
-		irPassLLVMIROptimizeByRange(N);
+        bool enableQuantization = N->irPasses & kNewtonirPassLLVMIRAutoQuantization;
+        bool enableOverload = N->irPasses & kNewtonirPassLLVMIREnableOverload;
+        bool enableBuiltinAssume = N->irPasses & kNewtonirPassLLVMIREnableBuiltinAssume;
+		irPassLLVMIROptimizeByRange(N, enableQuantization, enableOverload, enableBuiltinAssume);
 	}
 	/*
 	 *	Dot backend.


### PR DESCRIPTION
* sync issue-633

* Issue-637---improve-test-framework.

* rewrite test framework with tic-tok

* Issue-637---improve-test-framework.

* clone a dummy function for functions that are generated before

* Issue-637---improve-test-framework.

* remove the children functions if the parent function has been deleted

* Issue-637---improve-test-framework.

* remove from callerMap when the function is deleted; always keep the 'important' function to the bottomer pos than 'dummy' or 'new' one

* Issue-637---improve-test-framework.

* remove unused functions

* Issue-637---improve-test-framework.

* the range of GEP can be negative; the range of SHR cannot be negative

* Issue-637---improve-test-framework.

* the range of GEP can be negative; the range of SHR cannot be negative

* Issue-637---improve-test-framework.

* use a flag to control

* Issue-637---improve-test-framework.

* fix bug of issue-639

* Issue-637---improve-test-framework.

* reset bmx055yAcceleration

* Issue-637---improve-test-framework.

* fix the result error of sincosf, but the performance become worse. Check issue 641

* Issue-637---improve-test-framework.

* reconstruct auto_test, and collect timer info

* Issue-637---improve-test-framework.

* get the function results

* Issue-637---improve-test-framework.

* add timer collection and correctness check to the test framework

* Issue-637---improve-test-framework.

* reformat code

* Issue-637---improve-test-framework.

* sync issue-637

Addresses #642.

* ignore this case if it slow down

Addresses #642.

* fix commnets

* Issue-637---improve-test-framework.

* fix bugs with type conversion and range of sub

Addresses #642.

* fix bug of range of sqrt

Addresses #642.

* remove caller tree

Addresses #642.

* fix bug of result error in sincosf test case

Addresses #642.

* call global_DEC after overload function

Addresses #642.

* reinterpret cast double to integer value when meeting shift operand; use llvm API to swap operands of cmp inst

Addresses #642.

* fix the bug of shift operator

Addresses #642.

* add unit test of shift operand

Addresses #642.

* change one set of param

Addresses #642.

* fix bugs of cfg simp

Addresses #642.

* fix bug of shl

Addresses #642.

* shl should be positive

Addresses #642.

* update the ponter operand after function call

Addresses #642.

* I think the first operand of shl should be unsigned

Addresses #642.

* merge issue-628 manually

Addresses #644.

* upload memory alignment manually

Addresses #644.

* only shrink int type to promise correctness

Addresses #644.

* if one value shrink from high signed type to low unsigned type, like  to , we should update the related sign flag

Addresses #644.

* ignore sign operand

Addresses #644.

* only overload function after cfg

Addresses #647.

* check if subProgram is nullptr

Addresses #647.

* update inst sign flag for signed instructions

Addresses #647.

* only record lib size reduced

Addresses #647.

* it can be bool type

Addresses #647.

* we shouldn't remove srcInst, as it may be used in the latter instructions

Addresses #647.

* perf test of madgwick localy

Addresses #647.

* upload input date for madgwick

Addresses #647.

* add return check in auto test

Addresses #647.

* break down performance

Addresses #647.

* it may run out of memory if iterate 10 times, so change to 5

Addresses #647.

* we should use bash -c in system call

Addresses #647.

* mistake change of the last commit

Addresses #647.

* match castInst before shrinkage

Addresses #647.

* first version of kalman locally

Addresses #647.

* remove kalman local test; reset the modification of pedometer

Addresses #647.

* add nullptr check

Addresses #647.

* skip matching the destination type of GEP when its operand is a aggregate type

Addresses #647.

* const substitution skip the pointer

Addresses #647.

* update the overall perf in the script

Addresses #647.

* update get_break_down

Addresses #647.

* upload break down result

Addresses #647.

* update break down script

Addresses #647.

* use 0-200

Addresses #647.

* set args

Addresses #647.

* remove log file

Addresses #647.

* lhs of shl can be negative

Addresses #649.

* fix sign bit

Addresses #649.

* remove INT1 type compression

Addresses #649.

* to simplify the problem, only keep signed types

Addresses #649.

* use macro to control unsigned shrink

Addresses #649.

* reset bmx055 nt file

Addresses #647.

* test with/without bitwise/modulo op

Addresses #647.

* add Os option

Addresses #647.

* fix macro define

Addresses #647.

* Issue 651 - Implementation of auto-quantization (#652)

* merge issue-647

Addresses #651.

* add and correct accuracy in nt file

Addresses #651.

* correct test.nt

Addresses #651.

* upload Madgwick FP code

Addresses #651.

* compile Madgwick with different configs

Addresses #651.

* add some test config

Addresses #651.

* fix compile error of different version of Madgwick

Addresses #651.

* add SOFT_FLOAT config and show compile message

Addresses #651.

* builtin_assume test with Madgwick

Addresses #653.

* modify plot script for real sensor ranges

Addresses #653.

* set enableOverload and enableBuiltinAssume as options

Addresses #653.

* add enableOverload and enableBuiltinAssume config in markdown and makefile

Addresses #653.

* update Makefile by passing options in command line

Addresses #653.

* use DEBUG macro in e_exp.c

Addresses #653.

* add debug macro to some micro-benchmarks

Addresses #653.

* fix bugs of softfloat micro benchmarks

Addresses #653.

* add lowerBound and upperBound macro

Addresses #653.

* upload builtin_assume test shell

Addresses #653.

* enable overload

Addresses #653.

* compile e_j0 and e_y0 with sin/cos ieee implementation

Addresses #653.

* fix figure format

Addresses #653.

* should remove redundant function first, then clean callerMap

Addresses #653.

* add plot bitwise figure script

Addresses #653.

* modify plot bitwise figure script

Addresses #653.

* fix madgwick params config

Addresses #653.

* check accuracy

Addresses #653.

* comment printf and type explicit fix

Addresses #653.

* considering time consumption, we use a simple version of mulfix

Addresses #653.

* use >> instead of multiply

Addresses #653.

* only revert the quantized values before and after the type cast block

Addresses #653.

* explicit quantize

Addresses #653.

* basic structure of auto-quantization

Addresses #653.

* implement alloca, call, store, etc

Addresses #653.

* implement fmul/fdiv with constant operand

Addresses #653.

* implement fneg

Addresses #653.

* implement fixmul

Addresses #653.

* fix alloca, call, bitcast and simplify constant

Addresses #653.

* single-func quantization

Addresses #653.